### PR TITLE
Add `Shield::BearerToken` utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Add `Shield::HttpClient` that enables API and browser authentication in tests.
+- Add `Shield::BearerToken` utility
 
 ### Changed
 - Change `Shield::CryptoHelper#encrypt_and_sign` to accept and return a string.

--- a/docs/02-TYPE-NAMES.md
+++ b/docs/02-TYPE-NAMES.md
@@ -93,6 +93,7 @@
 ### Utilities
 
 - `BearerLoginHeaders`
+- `BearerToken`
 - `EmailConfirmationParams`
 - `EmailConfirmationSession`
 - `LoginHeaders`

--- a/docs/10-BEARER-LOGIN.md
+++ b/docs/10-BEARER-LOGIN.md
@@ -318,11 +318,7 @@ This token is revoked when the user logs out.
    end
    ```
 
-   You may need to add `BearerLogins::ShowPage` in `src/pages/bearer_logins/show_page.cr`, that displays the generated login token.
-
-   You display the token by calling `BearerLoginHelper.token(bearer_login, operation)`. This method prepends the *bearer login* ID to the raw token generated in the `CreateBearerLogin` operation, separated by a `.`.
-   
-   The resulting string is the final token expected to be used by clients to authenticate against the API.
+   You may need to add `BearerLogins::ShowPage` in `src/pages/bearer_logins/show_page.cr`, that displays the generated login token, thus: `BearerToken.new(operation, bearer_login).to_s`
 
    ---
    ```crystal
@@ -395,6 +391,18 @@ This token is revoked when the user logs out.
    ```
 
 1. Set up utilities:
+
+   ```crystal
+   # ->>> src/utilities/bearer_token.cr
+
+   class BearerToken # or `struct ...`
+     # ...
+     include Shield::BearerToken
+     # ...
+   end
+   ```
+
+   `Shield::BearerToken` is a type representing a bearer token.
 
    ```crystal
    # ->>> src/utilities/bearer_login_headers.cr

--- a/spec/shield/actions/api/authorization_pipes_spec.cr
+++ b/spec/shield/actions/api/authorization_pipes_spec.cr
@@ -45,10 +45,10 @@ describe Shield::Api::AuthorizationPipes do
         ) do |operation, bearer_login|
           bearer_login = bearer_login.not_nil!
 
-          bearer_token = BearerLoginHelper.token(bearer_login, operation)
+          token = BearerToken.new(operation, bearer_login)
 
           client = ApiClient.new
-          client.api_auth(bearer_token)
+          client.api_auth(token)
 
           response = client.exec(Api::Posts::Create)
 
@@ -67,10 +67,11 @@ describe Shield::Api::AuthorizationPipes do
         ) do |operation, bearer_login|
           bearer_login = bearer_login.not_nil!
 
-          bearer_token = BearerLoginHelper.token(bearer_login, operation)
+          token = BearerToken.new(operation, bearer_login)
 
           client = ApiClient.new
-          client.api_auth(bearer_token)
+          client.api_auth(token)
+
           response = client.exec(Api::Posts::Create)
 
           response.should send_json(403, authorized: false)
@@ -88,10 +89,11 @@ describe Shield::Api::AuthorizationPipes do
         ) do |operation, bearer_login|
           bearer_login = bearer_login.not_nil!
 
-          bearer_token = BearerLoginHelper.token(bearer_login, operation)
+          token = BearerToken.new(operation, bearer_login)
 
           client = ApiClient.new
-          client.api_auth(bearer_token)
+          client.api_auth(token)
+
           response = client.exec(Api::Posts::Create)
 
           response.should send_json(200, current_bearer_user: user.id)

--- a/spec/shield/actions/api/email_confirmation_current_user/create_spec.cr
+++ b/spec/shield/actions/api/email_confirmation_current_user/create_spec.cr
@@ -12,7 +12,7 @@ describe Shield::Api::EmailConfirmationCurrentUser::Create do
     ) do |operation, email_confirmation|
       email_confirmation = email_confirmation.not_nil!
 
-      token = EmailConfirmationHelper.token(email_confirmation, operation)
+      token = BearerToken.new(operation, email_confirmation)
 
       response = ApiClient.exec(
         Api::EmailConfirmationCurrentUser::Create,
@@ -30,7 +30,7 @@ describe Shield::Api::EmailConfirmationCurrentUser::Create do
 
   it "rejects invalid email confirmation token" do
     password = "password4APASSWORD<"
-    token = EmailConfirmationHelper.token(1, "abcdef")
+    token = BearerToken.new("abcdef", 1)
 
     response = ApiClient.exec(
       Api::EmailConfirmationCurrentUser::Create,

--- a/spec/shield/actions/api/email_confirmation_pipes_spec.cr
+++ b/spec/shield/actions/api/email_confirmation_pipes_spec.cr
@@ -11,7 +11,7 @@ describe Shield::Api::EmailConfirmationPipes do
       ) do |operation, email_confirmation|
         email_confirmation = email_confirmation.not_nil!
 
-        token = EmailConfirmationHelper.token(email_confirmation, operation)
+        token = BearerToken.new(operation, email_confirmation)
 
         response = ApiClient.exec(
           Api::EmailConfirmationCurrentUser::Create,
@@ -36,7 +36,7 @@ describe Shield::Api::EmailConfirmationPipes do
       ) do |operation, email_confirmation|
         email_confirmation = email_confirmation.not_nil!
 
-        token = EmailConfirmationHelper.token(email_confirmation, operation)
+        token = BearerToken.new(operation, email_confirmation)
 
         response = ApiClient.exec(
           Api::EmailConfirmationCurrentUser::Create,

--- a/spec/shield/actions/api/email_confirmations/edit_spec.cr
+++ b/spec/shield/actions/api/email_confirmations/edit_spec.cr
@@ -17,7 +17,7 @@ describe Shield::Api::EmailConfirmations::Edit do
     ) do |operation, email_confirmation|
       email_confirmation = email_confirmation.not_nil!
 
-      token = EmailConfirmationHelper.token(email_confirmation, operation)
+      token = BearerToken.new(operation, email_confirmation)
 
       client = ApiClient.new
       client.api_auth(user, password)
@@ -33,7 +33,7 @@ describe Shield::Api::EmailConfirmations::Edit do
     email = "user@domain.tld"
     password = "password4APASSWORD<"
 
-    token = EmailConfirmationHelper.token(1, "abcdef")
+    token = BearerToken.new("abcdef", 1)
 
     client = ApiClient.new
     client.api_auth(email, password)

--- a/spec/shield/actions/api/login_helpers_spec.cr
+++ b/spec/shield/actions/api/login_helpers_spec.cr
@@ -40,10 +40,10 @@ describe Shield::Api::LoginHelpers do
       ) do |operation, bearer_login|
         bearer_login = bearer_login.not_nil!
 
-        bearer_token = BearerLoginHelper.token(bearer_login, operation)
+        token = BearerToken.new(operation, bearer_login)
 
         client = ApiClient.new
-        client.api_auth(bearer_token)
+        client.api_auth(token)
         response = client.exec(Api::Posts::Index)
 
         response.should send_json(200, current_bearer_user: user.id)

--- a/spec/shield/actions/api/login_pipes_spec.cr
+++ b/spec/shield/actions/api/login_pipes_spec.cr
@@ -33,10 +33,10 @@ describe Shield::Api::LoginPipes do
       ) do |operation, bearer_login|
         bearer_login = bearer_login.not_nil!
 
-        bearer_token = BearerLoginHelper.token(bearer_login, operation)
+        token = BearerToken.new(operation, bearer_login)
 
         client = ApiClient.new
-        client.api_auth(bearer_token)
+        client.api_auth(token)
         response = client.exec(Api::Posts::Index)
 
         response.should send_json(200, current_bearer_user: user.id)
@@ -80,10 +80,10 @@ describe Shield::Api::LoginPipes do
       ) do |operation, bearer_login|
         bearer_login = bearer_login.not_nil!
 
-        bearer_token = BearerLoginHelper.token(bearer_login, operation)
+        token = BearerToken.new(operation, bearer_login)
 
         client = ApiClient.new
-        client.api_auth(bearer_token)
+        client.api_auth(token)
         response = client.exec(Api::Posts::New)
 
         response.should send_json(200, logged_in: true)

--- a/spec/shield/actions/api/password_reset_pipes_spec.cr
+++ b/spec/shield/actions/api/password_reset_pipes_spec.cr
@@ -16,7 +16,7 @@ describe Shield::Api::PasswordResetPipes do
       ) do |operation, password_reset|
         password_reset = password_reset.not_nil!
 
-        token = PasswordResetHelper.token(password_reset, operation)
+        token = BearerToken.new(operation, password_reset)
 
         response = ApiClient.exec(
           Api::PasswordResets::Update,
@@ -46,7 +46,7 @@ describe Shield::Api::PasswordResetPipes do
       ) do |operation, password_reset|
         password_reset = password_reset.not_nil!
 
-        token = PasswordResetHelper.token(password_reset, operation)
+        token = BearerToken.new(operation, password_reset)
 
         response = ApiClient.exec(
           Api::PasswordResets::Update,

--- a/spec/shield/actions/api/password_resets/update_spec.cr
+++ b/spec/shield/actions/api/password_resets/update_spec.cr
@@ -15,7 +15,7 @@ describe Shield::Api::PasswordResets::Update do
     ) do |operation, password_reset|
       password_reset = password_reset.not_nil!
 
-      token = PasswordResetHelper.token(password_reset, operation)
+      token = BearerToken.new(operation, password_reset)
 
       response = ApiClient.exec(
         Api::PasswordResets::Update,
@@ -43,11 +43,13 @@ describe Shield::Api::PasswordResets::Update do
       remote_ip: Socket::IPAddress.new("128.0.0.2", 5000)
     )
 
-    token = PasswordResetHelper.token(1, "abcdef")
+    token = BearerToken.new("abcdef", 1)
 
-    response = ApiClient.exec(Api::PasswordResets::Update, token: token, user: {
-      password: new_password
-    })
+    response = ApiClient.exec(
+      Api::PasswordResets::Update,
+      token: token,
+      user: {password: new_password}
+    )
 
     response.should send_json(403, {status: "failure"})
   end

--- a/spec/shield/helpers/bearer_login_helper_spec.cr
+++ b/spec/shield/helpers/bearer_login_helper_spec.cr
@@ -7,45 +7,4 @@ describe Shield::BearerLoginHelper do
       BearerLoginHelper.scope(CurrentUser::Show).should eq("current_user.show")
     end
   end
-
-  describe ".bearer_token" do
-    it "works" do
-      BearerLoginHelper.token(1, "abcdef").should eq("1.abcdef")
-    end
-  end
-
-  describe ".authorization_header" do
-    it "works" do
-      BearerLoginHelper.bearer_header(1, "abcdef").should eq("Bearer 1.abcdef")
-    end
-  end
-
-  describe ".token_from_headers" do
-    it "works" do
-      all_headers = [
-        HTTP::Headers{"Authorization" => "Bearer 123.abcdef"},
-        HTTP::Headers{"Authorization" => "Bearer  .abcdef"},
-        HTTP::Headers{"Authorization" => "Bearer abcdef "},
-        HTTP::Headers{"Authorization" => "Bearer 123"},
-        HTTP::Headers{"Authorization" => "Bearer 123abc"},
-      ]
-
-      all_headers.each do |headers|
-        BearerLoginHelper.token_from_headers(headers).should_not be_nil
-      end
-    end
-
-    it "rejects invalid header" do
-      all_headers = [
-        HTTP::Headers{"Authorization" => "Bearer 123.abcdef ghi"},
-        HTTP::Headers{"Authorization" => "Basic 123.abcdef"},
-        HTTP::Headers{"Authorization" => "123.abcdef"},
-        HTTP::Headers{"Authorization" => "Bearer "},
-      ]
-
-      all_headers.each do |headers|
-        BearerLoginHelper.token_from_headers(headers).should be_nil
-      end
-    end
-  end
 end

--- a/spec/shield/utilities/mixins/bearer_login_verifier_spec.cr
+++ b/spec/shield/utilities/mixins/bearer_login_verifier_spec.cr
@@ -12,14 +12,11 @@ describe Shield::BearerLoginVerifier do
         bearer_login = bearer_login.not_nil!
 
         headers = HTTP::Headers{
-          "Authorization" => BearerLoginHelper.bearer_header(
-            bearer_login,
-            operation
-          )
+          "Authorization" => BearerToken.new(operation, bearer_login).to_header
         }
 
         headers_2 = HTTP::Headers{
-          "Authorization" => BearerLoginHelper.bearer_header(1, "abcdefghij")
+          "Authorization" => BearerToken.new("abcdefghij", 1).to_header
         }
 
         BearerLoginHeaders.new(headers).verify.should be_a(BearerLogin)

--- a/spec/shield/utilities/mixins/bearer_token_spec.cr
+++ b/spec/shield/utilities/mixins/bearer_token_spec.cr
@@ -1,0 +1,38 @@
+require "../../../spec_helper"
+
+describe Shield::BearerToken do
+  describe "#to_header" do
+    it "works" do
+      BearerToken.new("abcdef", 1).to_header.should eq("Bearer 1.abcdef")
+    end
+  end
+
+  describe ".from_headers" do
+    it "works" do
+      all_headers = [
+        HTTP::Headers{"Authorization" => "Bearer 123.abcdef"},
+        HTTP::Headers{"Authorization" => "Bearer  .abcdef"},
+        HTTP::Headers{"Authorization" => "Bearer abcdef "},
+        HTTP::Headers{"Authorization" => "Bearer 123"},
+        HTTP::Headers{"Authorization" => "Bearer 123abc"},
+      ]
+
+      all_headers.each do |headers|
+        BearerToken.from_headers(headers).should be_a(BearerToken)
+      end
+    end
+
+    it "rejects invalid header" do
+      all_headers = [
+        HTTP::Headers{"Authorization" => "Bearer 123.abcdef ghi"},
+        HTTP::Headers{"Authorization" => "Basic 123.abcdef"},
+        HTTP::Headers{"Authorization" => "123.abcdef"},
+        HTTP::Headers{"Authorization" => "Bearer "},
+      ]
+
+      all_headers.each do |headers|
+        BearerToken.from_headers(headers).should be_nil
+      end
+    end
+  end
+end

--- a/spec/shield/utilities/mixins/password_reset_verifier_spec.cr
+++ b/spec/shield/utilities/mixins/password_reset_verifier_spec.cr
@@ -15,8 +15,8 @@ describe Shield::PasswordResetVerifier do
       ) do |operation, password_reset|
         password_reset = password_reset.not_nil!
 
-        token = PasswordResetHelper.token(password_reset, operation)
-        token_2 = PasswordResetHelper.token(1, "abcdefghij")
+        token = BearerToken.new(operation, password_reset)
+        token_2 = BearerToken.new("abcdef", 1)
 
         PasswordResetParams.new(params(token: token))
           .verify

--- a/spec/support/app/src/utilities/bearer_token.cr
+++ b/spec/support/app/src/utilities/bearer_token.cr
@@ -1,0 +1,3 @@
+struct BearerToken
+  include Shield::BearerToken
+end

--- a/src/shield/actions/api/bearer_logins/create.cr
+++ b/src/shield/actions/api/bearer_logins/create.cr
@@ -31,7 +31,7 @@ module Shield::Api::BearerLogins::Create
         message: "Copy the token now; it will only be shown once!",
         data: {
           bearer_login: BearerLoginSerializer.new(bearer_login),
-          token: BearerLoginHelper.token(bearer_login, operation)
+          token: BearerToken.new(operation, bearer_login)
         }
       })
     end

--- a/src/shield/actions/api/current_login/create.cr
+++ b/src/shield/actions/api/current_login/create.cr
@@ -23,7 +23,7 @@ module Shield::Api::CurrentLogin::Create
         message: "Copy the token now; it will only be shown once!",
         data: {
           login: LoginSerializer.new(login),
-          token: LoginHelper.token(login, operation)
+          token: BearerToken.new(operation, login)
         }
       })
     end

--- a/src/shield/actions/api/email_confirmation_current_user/update.cr
+++ b/src/shield/actions/api/email_confirmation_current_user/update.cr
@@ -34,9 +34,9 @@ module Shield::Api::EmailConfirmationCurrentUser::Update
           message: success_message(operation),
           data: {
             user: UserSerializer.new(user),
-            token: EmailConfirmationHelper.token(
-              operation.email_confirmation.not_nil!,
-              operation.start_email_confirmation.not_nil!
+            token: BearerToken.new(
+              operation.start_email_confirmation.not_nil!,
+              operation.email_confirmation.not_nil!
             )
           }
         })

--- a/src/shield/actions/api/email_confirmations/create.cr
+++ b/src/shield/actions/api/email_confirmations/create.cr
@@ -30,10 +30,7 @@ module Shield::Api::EmailConfirmations::Create
         json({
           status: "success",
           message: "Development mode: No need to check your mail.",
-          data: {token: EmailConfirmationHelper.token(
-            email_confirmation,
-            operation
-          )}
+          data: {token: BearerToken.new(operation, email_confirmation)}
         })
       end
     end

--- a/src/shield/actions/api/password_resets/create.cr
+++ b/src/shield/actions/api/password_resets/create.cr
@@ -34,7 +34,7 @@ module Shield::Api::PasswordResets::Create
         json({
           status: "success",
           message: "Development mode: No need to check your mail.",
-          data: {token: PasswordResetHelper.token(password_reset, operation)}
+          data: {token: BearerToken.new(operation, password_reset)}
         })
       end
     end

--- a/src/shield/helpers/bearer_login_helper.cr
+++ b/src/shield/helpers/bearer_login_helper.cr
@@ -2,39 +2,6 @@ module Shield::BearerLoginHelper
   macro extended
     extend self
 
-    def token(
-      bearer_login : BearerLogin,
-      operation : CreateBearerLogin
-    ) : String
-      token(bearer_login.id, operation.token)
-    end
-
-    def token(id, token : String) : String
-      LoginHelper.token(id, token)
-    end
-
-    def bearer_header(
-      bearer_login : BearerLogin,
-      operation : CreateBearerLogin
-    ) : String
-      bearer_header(bearer_login.id, operation.token)
-    end
-
-    def bearer_header(id, token : String)
-      LoginHelper.bearer_header(id, token)
-    end
-
-    def token_from_headers(request : HTTP::Request)
-      token_from_headers(request.headers)
-    end
-
-    # Expects "Authorization" header of format:
-    # "Authorization: Bearer <ID>.<TOKEN>",
-    # where <ID> = bearer login id, <TOKEN> = bearer login token
-    def token_from_headers(headers : HTTP::Headers) : String?
-      LoginHelper.token_from_headers(headers)
-    end
-
     def scope(action : Lucky::Action.class) : String
       action.name.gsub("::", '.').underscore
     end

--- a/src/shield/helpers/email_confirmation_helper.cr
+++ b/src/shield/helpers/email_confirmation_helper.cr
@@ -6,26 +6,19 @@ module Shield::EmailConfirmationHelper
       email_confirmation : EmailConfirmation,
       operation : StartEmailConfirmation
     ) : String
-      email_confirmation_url(token email_confirmation, operation)
+      email_confirmation_url(email_confirmation.id, operation.token)
     end
 
     def email_confirmation_url(id, token : String) : String
-      email_confirmation_url(token id, token)
+      email_confirmation_url(BearerToken.new token, id)
+    end
+
+    def email_confirmation_url(token : BearerToken) : String
+      email_confirmation_url(token.to_s)
     end
 
     def email_confirmation_url(token : String) : String
       EmailConfirmations::Show.url(token: token)
-    end
-
-    def token(
-      email_confirmation : EmailConfirmation,
-      operation : StartEmailConfirmation
-    ) : String
-      token(email_confirmation.id, operation.token)
-    end
-
-    def token(id, token : String) : String
-      LoginHelper.token(id, token)
     end
   end
 end

--- a/src/shield/helpers/login_helper.cr
+++ b/src/shield/helpers/login_helper.cr
@@ -1,37 +1,5 @@
 module Shield::LoginHelper
   macro extended
     extend self
-
-    def token(login : Login, operation : LogUserIn) : String
-      token(login.id, operation.token)
-    end
-
-    def token(id, token : String) : String
-      "#{id}.#{token}"
-    end
-
-    def bearer_header(
-      login : Login,
-      operation : LogUserIn
-    ) : String
-      bearer_header(login.id, operation.token)
-    end
-
-    def bearer_header(id, token : String)
-      "Bearer #{token(id, token)}"
-    end
-
-    def token_from_headers(request : HTTP::Request)
-      token_from_headers(request.headers)
-    end
-
-    # Expects "Authorization" header of format:
-    # "Authorization: Bearer <ID>.<TOKEN>",
-    # where <ID> = login id, <TOKEN> = login token
-    def token_from_headers(headers : HTTP::Headers) : String?
-      header = headers["Authorization"]?.try &.split
-      return unless header.try(&.size) == 2 && header.try(&.[0]?) == "Bearer"
-      header.try &.[1]?
-    end
   end
 end

--- a/src/shield/helpers/password_reset_helper.cr
+++ b/src/shield/helpers/password_reset_helper.cr
@@ -6,26 +6,19 @@ module Shield::PasswordResetHelper
       password_reset : PasswordReset,
       operation : StartPasswordReset
     ) : String
-      password_reset_url(token password_reset, operation)
+      password_reset_url(password_reset.id, operation.token)
     end
 
     def password_reset_url(id, token : String) : String
-      password_reset_url(token id, token)
+      password_reset_url(BearerToken.new token, id)
+    end
+
+    def password_reset_url(token : BearerToken) : String
+      password_reset_url(token.to_s)
     end
 
     def password_reset_url(token : String) : String
       PasswordResets::Show.url(token: token)
-    end
-
-    def token(
-      password_reset : PasswordReset,
-      operation : StartPasswordReset
-    ) : String
-      token(password_reset.id, operation.token)
-    end
-
-    def token(id, token : String) : String
-      LoginHelper.token(id, token)
     end
   end
 end

--- a/src/shield/http_client.cr
+++ b/src/shield/http_client.cr
@@ -1,7 +1,11 @@
 module Shield::HttpClient
   macro included
     def api_auth(token : String)
-      headers("Authorization": "Bearer #{token}")
+      api_auth(BearerToken.new token)
+    end
+
+    def api_auth(token : BearerToken)
+      headers("Authorization": token.to_header)
     end
 
     def api_auth(
@@ -28,8 +32,10 @@ module Shield::HttpClient
         params(email: email, password: password),
         remote_ip: remote_ip
       ) do |operation, login|
-        bearer_header = LoginHelper.bearer_header(login.not_nil!, operation)
-        headers("Authorization": bearer_header)
+        headers("Authorization": BearerToken.new(
+          operation,
+          login.not_nil!
+        ).to_header)
       end
 
       self

--- a/src/shield/utilities/bearer_login_headers.cr
+++ b/src/shield/utilities/bearer_login_headers.cr
@@ -6,17 +6,16 @@ module Shield::BearerLoginHeaders
     end
 
     def bearer_login_id : Int64?
-      token_from_headers.try &.[0]?.try &.to_i64
-    rescue
+      token_from_headers.try &.id
     end
 
     def bearer_login_token : String?
-      token_from_headers.try &.[1]?
+      token_from_headers.try &.token
     end
 
     @[Memoize]
     private def token_from_headers
-      BearerLoginHelper.token_from_headers(@headers).try &.split('.', 2)
+      BearerToken.from_headers(@headers)
     end
   end
 end

--- a/src/shield/utilities/bearer_token.cr
+++ b/src/shield/utilities/bearer_token.cr
@@ -1,0 +1,57 @@
+module Shield::BearerToken
+  macro included
+    getter :id, :token
+
+    def self.new(operation, record)
+      new(operation.token, record.id)
+    end
+
+    def self.new(token : String, id)
+      new(token, id.to_i64)
+    rescue ArgumentError
+      new(token, nil)
+    end
+
+    def initialize(@token : String, @id : Int64?)
+    end
+
+    def self.new(token : String)
+      id, _, tkn = token.partition('.')
+      id = id.empty? ? nil : id.to_i64
+      new(tkn, id)
+    rescue ArgumentError
+      new(token, nil)
+    end
+
+    def to_header : String
+      "Bearer #{to_s}"
+    end
+
+    def to_s(io)
+      io << @id
+      io << '.' if @id
+      io << @token
+    end
+
+    def to_json(json)
+      json.string(to_s)
+    end
+
+    def self.from_headers(request : HTTP::Request) : self?
+      from_headers(request.headers)
+    end
+
+    def self.from_headers(headers : HTTP::Headers) : self?
+      header = headers["Authorization"]?.try &.split
+      return unless header.try(&.size) == 2 && header.try(&.[0]?) == "Bearer"
+      header.try &.[1]?.try { |token| new(token) }
+    end
+
+    def self.from_params(
+      params : Avram::Paramable,
+      key : String | Symbol = "token"
+    ) : self?
+      params.get?(key.to_s).try { |token| new(token) }
+    end
+  end
+end

--- a/src/shield/utilities/email_confirmation_params.cr
+++ b/src/shield/utilities/email_confirmation_params.cr
@@ -6,17 +6,16 @@ module Shield::EmailConfirmationParams
     end
 
     def email_confirmation_id : Int64?
-      token_from_params.try &.[0]?.try &.to_i64
-    rescue
+      token_from_params.try &.id
     end
 
     def email_confirmation_token : String?
-      token_from_params.try &.[1]?
+      token_from_params.try &.token
     end
 
     @[Memoize]
     private def token_from_params
-      @params.get?("token").try &.split('.', 2)
+      BearerToken.from_params(@params)
     end
   end
 end

--- a/src/shield/utilities/email_confirmation_session.cr
+++ b/src/shield/utilities/email_confirmation_session.cr
@@ -26,8 +26,8 @@ module Shield::EmailConfirmationSession
     end
 
     def set(token : String) : self
-      id, _, token = token.partition('.')
-      set(id, token)
+      bearer_token = BearerToken.new(token)
+      set(bearer_token.id, bearer_token.token)
     end
 
     def set(id, token : String) : self

--- a/src/shield/utilities/login_headers.cr
+++ b/src/shield/utilities/login_headers.cr
@@ -6,17 +6,16 @@ module Shield::LoginHeaders
     end
 
     def login_id : Int64?
-      token_from_headers.try &.[0]?.try &.to_i64
-    rescue
+      token_from_headers.try &.id
     end
 
     def login_token : String?
-      token_from_headers.try &.[1]?
+      token_from_headers.try &.token
     end
 
     @[Memoize]
     private def token_from_headers
-      LoginHelper.token_from_headers(@headers).try &.split('.', 2)
+      BearerToken.from_headers(@headers)
     end
   end
 end

--- a/src/shield/utilities/password_reset_params.cr
+++ b/src/shield/utilities/password_reset_params.cr
@@ -6,17 +6,16 @@ module Shield::PasswordResetParams
     end
 
     def password_reset_id : Int64?
-      token_from_params.try &.[0]?.try &.to_i64
-    rescue
+      token_from_params.try &.id
     end
 
     def password_reset_token : String?
-      token_from_params.try &.[1]?
+      token_from_params.try &.token
     end
 
     @[Memoize]
     private def token_from_params
-      @params.get?("token").try &.split('.', 2)
+      BearerToken.from_params(@params)
     end
   end
 end

--- a/src/shield/utilities/password_reset_session.cr
+++ b/src/shield/utilities/password_reset_session.cr
@@ -26,8 +26,8 @@ module Shield::PasswordResetSession
     end
 
     def set(token : String) : self
-      id, _, token = token.partition('.')
-      set(id, token)
+      bearer_token = BearerToken.new(token)
+      set(bearer_token.id, bearer_token.token)
     end
 
     def set(id, token : String) : self


### PR DESCRIPTION
This shifts the responsibility of creating and parsing tokens from the various helpers to this one utility. It helps us avoid repeating the same logic across several helpers.

Before:

```crystal
# Bearer login token
BearerLoginHelper.token(bearer_login, operation)

# Email confirmation token
EmailConfirmationHelper.token(email_confirmation, operation)

# Login token
LoginHelper.token(login, operation)

# Password reset token
PasswordResetHelper.token(password_reset, operation)
```

After:

```crystal
# Bearer login token
BearerToken.new(operation, bearer_login)

# Email confirmation token
BearerToken.new(operation, email_confirmation)

# Login token
BearerToken.new(operation, login)

# Password reset token
BearerToken.new(operation, password_reset)
```
