### PR TITLE
Check association between respective models in nested operations

### DIFF
--- a/src/charms.cr
+++ b/src/charms.cr
@@ -286,6 +286,10 @@ module Avram
           assoc[:type].resolve.name == model_type.name
       end %}
 
+      {% unless assoc %}
+        {% raise "#{T} must have a has_one association with #{model_type}" %}
+      {% end %}
+
       after_save save_{{ name }}
 
       after_completed do |saved_record|


### PR DESCRIPTION
Check, at compile time, that a nested operation has a has_one association with its parent operation.