### PR TITLE
Always run `after_save` in update operations

### DIFF
--- a/docs/00-GETTING-STARTED.md
+++ b/docs/00-GETTING-STARTED.md
@@ -22,3 +22,5 @@ If you would rather start from scratch, generate a new *Lucky* project without a
 *Shield* patches *Lucky* and [*Avram*](https://github.com/luckyframework/avram) in a few places. This may lead to behaviours that are inconsistent with core *Lucky* and *Avram*. Take note of the following:
 
 1. *Shield* disables the default validation performed by *Avram* in save operations. See [#1209 (comment)](https://github.com/luckyframework/lucky/discussions/1209#discussioncomment-46030). You have to **explicitly** define validations for all attributes in save operations.
+
+1. *Avram* does not actually update a record if no columns changed. *Shield* updates, whether or not columns changed. See https://github.com/luckyframework/avram/issues/604

--- a/docs/00-GETTING-STARTED.md
+++ b/docs/00-GETTING-STARTED.md
@@ -23,4 +23,4 @@ If you would rather start from scratch, generate a new *Lucky* project without a
 
 1. *Shield* disables the default validation performed by *Avram* in save operations. See [#1209 (comment)](https://github.com/luckyframework/lucky/discussions/1209#discussioncomment-46030). You have to **explicitly** define validations for all attributes in save operations.
 
-1. *Avram* does not actually update a record if no columns changed. *Shield* updates, whether or not columns changed. See https://github.com/luckyframework/avram/issues/604
+1. In *Avram*, `after_save` hook does not run for updates if no columns changed. In *Shield*, it always runs, and inside the transation so that roll backs are possible. See https://github.com/luckyframework/avram/issues/604

--- a/src/charms.cr
+++ b/src/charms.cr
@@ -217,9 +217,8 @@ module Avram
 
       if valid?
         transaction_committed = database.transaction do
-          insert_or_update unless changes.empty? && persisted?
-          saved_record = record.not_nil!
-          after_save(saved_record)
+          insert_or_update if changes.any? || !persisted?
+          after_save(record.not_nil!)
           true
         end
 

--- a/src/charms.cr
+++ b/src/charms.cr
@@ -209,7 +209,7 @@ module Avram
       record.not_nil!
     end
 
-    # Always save, whether or not attributes changed.
+    # Always run `after_save`, whether or not attributes changed.
     #
     # See https://github.com/luckyframework/avram/issues/604
     def save : Bool

--- a/src/charms.cr
+++ b/src/charms.cr
@@ -217,7 +217,7 @@ module Avram
 
       if valid?
         transaction_committed = database.transaction do
-          insert_or_update
+          insert_or_update unless changes.empty? && persisted?
           saved_record = record.not_nil!
           after_save(saved_record)
           true

--- a/src/charms.cr
+++ b/src/charms.cr
@@ -223,12 +223,10 @@ module Avram
         end
 
         if transaction_committed
+          self.save_status = SaveStatus::Saved
           saved_record = record.not_nil!
           after_commit(saved_record)
           after_completed(saved_record)
-
-          self.save_status = SaveStatus::Saved
-
           Avram::Events::SaveSuccessEvent.publish(
             operation_class: self.class.name,
             attributes: generic_attributes

--- a/src/charms.cr
+++ b/src/charms.cr
@@ -218,15 +218,14 @@ module Avram
       if valid?
         transaction_committed = database.transaction do
           insert_or_update if changes.any? || !persisted?
-          after_save(record.not_nil!)
+          after_save(record!)
           true
         end
 
         if transaction_committed
           self.save_status = SaveStatus::Saved
-          saved_record = record.not_nil!
-          after_commit(saved_record)
-          after_completed(saved_record)
+          after_commit(record!)
+          after_completed(record!)
           Avram::Events::SaveSuccessEvent.publish(
             operation_class: self.class.name,
             attributes: generic_attributes

--- a/src/shield/operations/mixins/delete_session.cr
+++ b/src/shield/operations/mixins/delete_session.cr
@@ -2,6 +2,6 @@ module Shield::DeleteSession
   macro included
     needs session : Lucky::Session? = nil
 
-    after_completed delete_session
+    after_commit delete_session
   end
 end

--- a/src/shield/operations/mixins/notify_login.cr
+++ b/src/shield/operations/mixins/notify_login.cr
@@ -1,6 +1,6 @@
 module Shield::NotifyLogin
   macro included
-    after_completed notify_login
+    after_commit notify_login
 
     private def notify_login(login : Login)
       return unless login.user!.options!.login_notify

--- a/src/shield/operations/mixins/notify_password_change.cr
+++ b/src/shield/operations/mixins/notify_password_change.cr
@@ -1,6 +1,6 @@
 module Shield::NotifyPasswordChange
   macro included
-    after_completed notify_password_change
+    after_commit notify_password_change
 
     private def notify_password_change(user : User)
       return unless password_digest.changed?

--- a/src/shield/operations/mixins/send_welcome_email.cr
+++ b/src/shield/operations/mixins/send_welcome_email.cr
@@ -4,7 +4,7 @@ module Shield::SendWelcomeEmail
       send_user_welcome_email
     end
 
-    after_completed send_welcome_email
+    after_commit send_welcome_email
 
     private def send_user_welcome_email
       return unless user_email?

--- a/src/shield/operations/mixins/set_session.cr
+++ b/src/shield/operations/mixins/set_session.cr
@@ -2,6 +2,6 @@ module Shield::SetSession
   macro included
     needs session : Lucky::Session? = nil
 
-    after_completed set_session
+    after_commit set_session
   end
 end

--- a/src/shield/operations/reset_password.cr
+++ b/src/shield/operations/reset_password.cr
@@ -8,10 +8,6 @@ module Shield::ResetPassword
 
     after_save end_password_resets
 
-    after_completed do |saved_record|
-      end_password_resets(saved_record) if changes.empty?
-    end
-
     include Shield::UpdatePassword
     include Shield::DeleteSession
 

--- a/src/shield/operations/start_email_confirmation.cr
+++ b/src/shield/operations/start_email_confirmation.cr
@@ -2,7 +2,7 @@ module Shield::StartEmailConfirmation
   macro included
     permit_columns :email
 
-    after_completed send_email
+    after_commit send_email
 
     include Shield::SaveEmail
     include Shield::RequireIpAddress

--- a/src/shield/operations/start_password_reset.cr
+++ b/src/shield/operations/start_password_reset.cr
@@ -16,7 +16,7 @@ module Shield::StartPasswordReset
       send_guest_email
     end
 
-    after_completed send_email
+    after_commit send_email
 
     include Shield::RequireIpAddress
     include Shield::StartAuthentication

--- a/src/shield/operations/update_confirmed_email.cr
+++ b/src/shield/operations/update_confirmed_email.cr
@@ -2,10 +2,6 @@ module Shield::UpdateConfirmedEmail
   macro included
     after_save end_email_confirmations
 
-    after_completed do |saved_record|
-      end_email_confirmations(saved_record) if changes.empty?
-    end
-
     include Shield::SetEmailFromEmailConfirmation
     include Shield::SaveEmail
     include Shield::DeleteSession

--- a/src/shield/operations/update_email_confirmation_user.cr
+++ b/src/shield/operations/update_email_confirmation_user.cr
@@ -20,10 +20,6 @@ module Shield::UpdateEmailConfirmationUser
 
     after_save start_email_confirmation
 
-    after_completed do |saved_record|
-      start_email_confirmation(saved_record) if changes.empty?
-    end
-
     include Shield::UpdatePassword
 
     private def reset_email


### PR DESCRIPTION
Always run `after_save` in update operations, whether or not attributes changed.

See https://github.com/luckyframework/avram/issues/604