### PR TITLE
Allow skipping authentication cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Shield::PasswordAuthentication` utility
 - Add `Avram::NestedSaveOperation.has_one` macro
 - Add `Shield::HasOneSaveUserOptions` operation mixin
+- Add `Shield::SkipAuthenticationCache`
+- Add `Shield::Api::SkipAuthenticationCache`
 
 ### Fixed
 - Fix email enumeration protection failure in password resets.

--- a/docs/06-LOGIN.md
+++ b/docs/06-LOGIN.md
@@ -200,6 +200,13 @@
      # ...
      include Shield::CurrentLogin::Create
 
+     # Enable this to skip authentication caching.
+     #
+     # Authentication helpers are memoized. If you call any of the
+     # helpers after login is created, you may want to skip cache to
+     # fetch the latest status from the database.
+     #include Shield::SkipAuthenticationCache
+
      post "/login" do
        run_operation
      end

--- a/docs/10-BEARER-LOGIN.md
+++ b/docs/10-BEARER-LOGIN.md
@@ -380,8 +380,9 @@ For these purposes, *Shield* provides the following modules:
 - `Shield::Api::EmailConfirmations::Edit`
 - `Shield::Api::PasswordResets::Create`
 - `Shield::Api::PasswordResets::Update`
+- `Shield::Api::SkipAuthenticationCache`
 
-If your application decides to allow any of these functionalities via its API, the modules above should be `include`d in their respective API classes.
+If your application decides to allow any of these functionalities via its API, the modules above should be `include`d in their respective API actions.
 
 ### Other Types
 

--- a/spec/support/app/src/actions/api/current_login/create.cr
+++ b/spec/support/app/src/actions/api/current_login/create.cr
@@ -1,5 +1,6 @@
 class Api::CurrentLogin::Create < ApiAction
   include Shield::Api::CurrentLogin::Create
+  include Shield::Api::SkipAuthenticationCache
 
   post "/log-in" do
     run_operation

--- a/spec/support/app/src/actions/current_login/create.cr
+++ b/spec/support/app/src/actions/current_login/create.cr
@@ -1,5 +1,6 @@
 class CurrentLogin::Create < BrowserAction
   include Shield::CurrentLogin::Create
+  include Shield::SkipAuthenticationCache
 
   post "/log-in" do
     run_operation
@@ -10,16 +11,6 @@ class CurrentLogin::Create < BrowserAction
     response.headers["X-Login-Token"] = operation.token
     response.headers["X-User-ID"] = current_user!.id.to_s
     previous_def
-  end
-
-  # To skip cache
-  def current_user : User?
-    current_login.try &.user!
-  end
-
-  # To skip cache
-  def current_login : Login?
-    LoginSession.new(session).verify
   end
 
   def remote_ip : Socket::IPAddress?

--- a/src/shield/actions/api/skip_authentication_cache.cr
+++ b/src/shield/actions/api/skip_authentication_cache.cr
@@ -1,0 +1,13 @@
+module Shield::Api::SkipAuthenticationCache
+  macro included
+    include Shield::SkipAuthenticationCache
+
+    def current_bearer_user : User?
+      current_bearer_user__uncached
+    end
+
+    def current_bearer_login : BearerLogin?
+      current_bearer_login__uncached
+    end
+  end
+end

--- a/src/shield/actions/skip_authentication_cache.cr
+++ b/src/shield/actions/skip_authentication_cache.cr
@@ -1,0 +1,11 @@
+module Shield::SkipAuthenticationCache
+  macro included
+    def current_user : User?
+      current_user__uncached
+    end
+
+    def current_login : Login?
+      current_login__uncached
+    end
+  end
+end


### PR DESCRIPTION
Authentication helpers are memoized. If you call any of the helpers in an action where login status is likely to change (eg: `CurrentLogin::Create`), you may want to skip cache to fetch the latest status from the database.

A follow-up to #14