### PR TITLE
Add `Avram::Validations.validate_primary_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Shield::HasOneSaveUserOptions` operation mixin
 - Add `Shield::SkipAuthenticationCache`
 - Add `Shield::Api::SkipAuthenticationCache`
+- Add `Avram::Validations.validate_primary_key`
 
 ### Fixed
 - Fix email enumeration protection failure in password resets.
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove `Shield::HasOneCreateSaveUserOptions` operation mixin
 - Remove `Shield::HasOneUpdateSaveUserOptions` operation mixin
 - Remove `Avram::Box.has_one` macro
+- Remove `Avram::Validations.validate_exists_by_id`
 
 ## [0.6.0] - 2020-12-21
 

--- a/docs/13-VALIDATIONS.md
+++ b/docs/13-VALIDATIONS.md
@@ -14,15 +14,6 @@
 
   Checks that the given attributes are valid domains labels (such as *example* in 'example.com').
 
-- `.validate_exists_by_id`:
-
-  Checks that the given attribute is a valid ID of another model.
-
-  ```crystal
-  validate_exists_by_id user_id, query: UserQuery.new, message: "does not exist"
-  validate_exists_by_id post_id, query: PostQuery.new
-  ```
-
 - `.validate_http_url`:
 
   Checks that given attributes are valid HTTP URLs.
@@ -70,6 +61,15 @@
 - `.validate_positive_number`:
 
   Checks that the given attributes are positive numbers.
+
+- `.validate_primary_key`:
+
+  Checks that the given attribute is a valid ID of another model.
+
+  ```crystal
+  validate_primary_key user_id, query: UserQuery, message: "does not exist"
+  validate_primary_key post_id, query: PostQuery.new
+  ```
 
 - `.validate_slug`:
 

--- a/spec/avram/validations_spec.cr
+++ b/spec/avram/validations_spec.cr
@@ -712,7 +712,7 @@ describe Avram::Validations do
     end
   end
 
-  describe "#validate_exists_by_id" do
+  describe "#validate_primary_key" do
     it "accepts existing ID" do
       user_id = Avram::Attribute(Int64?).new(
         :id,
@@ -721,7 +721,7 @@ describe Avram::Validations do
         param_key: "user"
       )
 
-      Avram::Validations.validate_exists_by_id user_id, query: UserQuery.new
+      Avram::Validations.validate_primary_key user_id, query: UserQuery
       user_id.valid?.should be_true
     end
 
@@ -733,7 +733,7 @@ describe Avram::Validations do
         param_key: "user"
       )
 
-      Avram::Validations.validate_exists_by_id user_id, query: UserQuery.new
+      Avram::Validations.validate_primary_key user_id, query: UserQuery
       user_id.valid?.should be_false
     end
   end

--- a/src/charms.cr
+++ b/src/charms.cr
@@ -426,15 +426,26 @@ module Avram
       end
     end
 
-    def validate_exists_by_id(
+    def validate_primary_key(
       attribute,
       *,
-      query,
+      query : Queryable,
       message : Attribute::ErrorMessage = "does not exist"
     )
       attribute.value.try do |value|
-        attribute.add_error(message) unless query.id(value).first?
+        unless query.where(query.primary_key_name, value).first?
+          attribute.add_error(message)
+        end
       end
+    end
+
+    def validate_primary_key(
+      attribute,
+      *,
+      query : Queryable.class,
+      message : Attribute::ErrorMessage = "does not exist"
+    )
+      validate_primary_key(attribute, query: query.new, message: message)
     end
 
     def validate_not_pwned(

--- a/src/shield/operations/create_bearer_login.cr
+++ b/src/shield/operations/create_bearer_login.cr
@@ -4,7 +4,7 @@ module Shield::CreateBearerLogin
 
     before_save do
       validate_required name, user_id
-      validate_exists_by_id user_id, query: UserQuery.new
+      validate_primary_key user_id, query: UserQuery
       validate_name_unique
     end
 

--- a/src/shield/operations/save_user_options.cr
+++ b/src/shield/operations/save_user_options.cr
@@ -4,7 +4,7 @@ module Shield::SaveUserOptions
 
     before_save do
       validate_required login_notify, password_notify, user_id
-      validate_exists_by_id user_id, query: UserQuery.new
+      validate_primary_key user_id, query: UserQuery
     end
   end
 end


### PR DESCRIPTION
Replaces `Avram::Validations.validate_exists_by_id`, which wrongly assumed the primary key will always be named `id`.