### PR TITLE
Remove default values from all operation `.needs` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove `Shield::HasOneUpdateSaveUserOptions` operation mixin
 - Remove `Avram::Box.has_one` macro
 - Remove `Avram::Validations.validate_exists_by_id`
+- Remove default values from all operation `.needs` calls
 
 ## [0.6.0] - 2020-12-21
 

--- a/docs/04-USER.md
+++ b/docs/04-USER.md
@@ -177,7 +177,7 @@
      include Shield::CurrentUser::Edit
 
      get "/account/edit" do
-       operation = UpdateCurrentUser.new(user)
+       operation = UpdateCurrentUser.new(user, current_login: current_login)
        html EditPage, operation: operation
      end
      # ...

--- a/docs/06-LOGIN.md
+++ b/docs/06-LOGIN.md
@@ -174,7 +174,7 @@
      include Shield::CurrentLogin::New
 
      get "/login" do
-       operation = LogUserIn.new(remote_ip: remote_ip)
+       operation = LogUserIn.new(remote_ip: remote_ip, session: session)
        html NewPage, operation: operation
      end
      # ...

--- a/docs/09-EMAIL-CONFIRMATION.md
+++ b/docs/09-EMAIL-CONFIRMATION.md
@@ -449,7 +449,12 @@ This is particularly important, since email addresses are usually the only means
      include Shield::EmailConfirmationCurrentUser::Edit
 
      get "/account/edit" do
-       operation = UpdateCurrentUser.new(user, remote_ip: remote_ip)
+       operation = UpdateCurrentUser.new(
+         user,
+         remote_ip: remote_ip,
+         current_login: current_login
+       )
+
        html EditPage, operation: operation
      end
      # ...

--- a/spec/shield/operations/register_email_confirmation_user_spec.cr
+++ b/spec/shield/operations/register_email_confirmation_user_spec.cr
@@ -42,6 +42,7 @@ describe Shield::RegisterEmailConfirmationUser do
         user_options: {login_notify: true, password_notify: true}
       ),
       email_confirmation: email_confirmation,
+      session: nil
     )
 
     email_confirmation = email_confirmation.reload

--- a/spec/shield/operations/update_confirmed_email_spec.cr
+++ b/spec/shield/operations/update_confirmed_email_spec.cr
@@ -60,7 +60,11 @@ describe Shield::UpdateConfirmedEmail do
     email_confirmation_4.active?.should be_true
     email_confirmation_5.active?.should be_true
 
-    UpdateConfirmedEmail.update!(user, email_confirmation: email_confirmation)
+    UpdateConfirmedEmail.update!(
+      user,
+      email_confirmation: email_confirmation,
+      session: nil
+    )
 
     email_confirmation.reload.active?.should be_false
     email_confirmation_2.reload.active?.should be_false

--- a/spec/support/app/src/actions/current_login/new.cr
+++ b/spec/support/app/src/actions/current_login/new.cr
@@ -2,7 +2,7 @@ class CurrentLogin::New < BrowserAction
   include Shield::CurrentLogin::New
 
   get "/log-in" do
-    operation = LogUserIn.new(remote_ip: remote_ip)
+    operation = LogUserIn.new(remote_ip: remote_ip, session: session)
     html NewPage, operation: operation
   end
 end

--- a/spec/support/app/src/actions/current_user/edit.cr
+++ b/spec/support/app/src/actions/current_user/edit.cr
@@ -4,7 +4,12 @@ class CurrentUser::Edit < BrowserAction
   skip :pin_login_to_ip_address
 
   get "/ec/profile/edit" do
-    operation = UpdateCurrentUser.new(user, remote_ip: remote_ip)
+    operation = UpdateCurrentUser.new(
+      user,
+      remote_ip: remote_ip,
+      current_login: current_login
+    )
+
     html EditPage, operation: operation
   end
 end

--- a/spec/support/app/src/actions/regular_current_user/edit.cr
+++ b/spec/support/app/src/actions/regular_current_user/edit.cr
@@ -4,7 +4,7 @@ class RegularCurrentUser::Edit < BrowserAction
   skip :pin_login_to_ip_address
 
   get "/profile/edit" do
-    operation = UpdateRegularCurrentUser.new(user)
+    operation = UpdateRegularCurrentUser.new(user, current_login: current_login)
     html EditPage, operation: operation
   end
 end

--- a/spec/support/app/src/actions/users/edit.cr
+++ b/spec/support/app/src/actions/users/edit.cr
@@ -4,7 +4,7 @@ class Users::Edit < BrowserAction
   skip :check_authorization
 
   get "/users/:user_id/edit" do
-    operation = UpdateUser.new(user)
+    operation = UpdateUser.new(user, current_login: current_login)
     html EditPage, operation: operation
   end
 

--- a/src/shield/actions/api/current_login/create.cr
+++ b/src/shield/actions/api/current_login/create.cr
@@ -7,7 +7,11 @@ module Shield::Api::CurrentLogin::Create
     # end
 
     def run_operation
-      LogUserIn.create(params, remote_ip: remote_ip) do |operation, login|
+      LogUserIn.create(
+        params,
+        remote_ip: remote_ip,
+        session: nil
+      ) do |operation, login|
         if login
           do_run_operation_succeeded(operation, login.not_nil!)
         else

--- a/src/shield/actions/api/current_login/destroy.cr
+++ b/src/shield/actions/api/current_login/destroy.cr
@@ -7,7 +7,7 @@ module Shield::Api::CurrentLogin::Destroy
     # end
 
     def run_operation
-      LogUserOut.update(login) do |operation, updated_login|
+      LogUserOut.update(login, session: nil) do |operation, updated_login|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_login)
         else

--- a/src/shield/actions/api/email_confirmation_current_user/create.cr
+++ b/src/shield/actions/api/email_confirmation_current_user/create.cr
@@ -30,7 +30,8 @@ module Shield::Api::EmailConfirmationCurrentUser::Create
     private def register_user(email_confirmation)
       RegisterCurrentUser.create(
         params,
-        email_confirmation: email_confirmation
+        email_confirmation: email_confirmation,
+        session: nil
       ) do |operation, user|
         if user
           do_run_operation_succeeded(operation, user.not_nil!)

--- a/src/shield/actions/api/email_confirmation_pipes.cr
+++ b/src/shield/actions/api/email_confirmation_pipes.cr
@@ -11,7 +11,7 @@ module Shield::Api::EmailConfirmationPipes
         email_confirmation.not_nil!.ip_address == remote_ip.try &.address
         continue
       else
-        EndEmailConfirmation.update!(email_confirmation.not_nil!)
+        EndEmailConfirmation.update!(email_confirmation.not_nil!, session: nil)
         response.status_code = 403
         do_pin_email_confirmation_to_ip_address_failed
       end

--- a/src/shield/actions/api/email_confirmations/edit.cr
+++ b/src/shield/actions/api/email_confirmations/edit.cr
@@ -45,7 +45,8 @@ module Shield::Api::EmailConfirmations::Edit
     private def update_email(email_confirmation)
       UpdateConfirmedEmail.update(
         email_confirmation.user!.not_nil!,
-        email_confirmation: email_confirmation
+        email_confirmation: email_confirmation,
+        session: nil
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)

--- a/src/shield/actions/api/login_pipes.cr
+++ b/src/shield/actions/api/login_pipes.cr
@@ -26,7 +26,7 @@ module Shield::Api::LoginPipes
         current_login!.ip_address == remote_ip.try &.address
         continue
       else
-        LogUserOut.update!(current_login!)
+        LogUserOut.update!(current_login!, session: nil)
         response.status_code = 403
         do_pin_login_to_ip_address_failed
       end

--- a/src/shield/actions/api/password_reset_pipes.cr
+++ b/src/shield/actions/api/password_reset_pipes.cr
@@ -10,7 +10,7 @@ module Shield::Api::PasswordResetPipes
         password_reset.not_nil!.ip_address == remote_ip.try &.address
         continue
       else
-        EndPasswordReset.update!(password_reset.not_nil!)
+        EndPasswordReset.update!(password_reset.not_nil!, session: nil)
         response.status_code = 403
         do_pin_password_reset_to_ip_address_failed
       end

--- a/src/shield/actions/api/password_resets/update.cr
+++ b/src/shield/actions/api/password_resets/update.cr
@@ -27,6 +27,7 @@ module Shield::Api::PasswordResets::Update
       ResetPassword.update(
         password_reset.user!,
         params,
+        session: nil,
         current_login: current_login
       ) do |operation, updated_user|
         if operation.saved?

--- a/src/shield/actions/current_login/new.cr
+++ b/src/shield/actions/current_login/new.cr
@@ -3,7 +3,7 @@ module Shield::CurrentLogin::New
     skip :require_logged_in
 
     # get "/login" do
-    #   operation = LogUserIn.new(remote_ip: remote_ip)
+    #   operation = LogUserIn.new(remote_ip: remote_ip, session: session)
     #   html NewPage, operation: operation
     # end
   end

--- a/src/shield/actions/current_user/edit.cr
+++ b/src/shield/actions/current_user/edit.cr
@@ -3,7 +3,7 @@ module Shield::CurrentUser::Edit
     skip :require_logged_out
 
     # get "/account/edit" do
-    #   operation = UpdateCurrentUser.new(user)
+    #   operation = UpdateCurrentUser.new(user, current_login: current_login)
     #   html EditPage, operation: operation
     # end
 

--- a/src/shield/actions/email_confirmation_current_user/edit.cr
+++ b/src/shield/actions/email_confirmation_current_user/edit.cr
@@ -3,7 +3,12 @@ module Shield::EmailConfirmationCurrentUser::Edit
     include Shield::CurrentUser::Edit
 
     # get "/account/edit" do
-    #   operation = UpdateCurrentUser.new(user, remote_ip: remote_ip)
+    #   operation = UpdateCurrentUser.new(
+    #     user,
+    #     remote_ip: remote_ip,
+    #     current_login: current_login
+    #   )
+    #
     #   html EditPage, operation: operation
     # end
   end

--- a/src/shield/actions/email_confirmation_current_user/new.cr
+++ b/src/shield/actions/email_confirmation_current_user/new.cr
@@ -24,7 +24,8 @@ module Shield::EmailConfirmationCurrentUser::New
     private def render_form(utility, email_confirmation)
       operation = RegisterCurrentUser.new(
         email: email_confirmation.email,
-        email_confirmation: email_confirmation
+        email_confirmation: email_confirmation,
+        session: session
       );
 
       html NewPage, operation: operation

--- a/src/shield/actions/password_resets/edit.cr
+++ b/src/shield/actions/password_resets/edit.cr
@@ -20,7 +20,12 @@ module Shield::PasswordResets::Edit
     end
 
     private def render_form(utility, password_reset)
-      operation = ResetPassword.new(utility.password_reset!.user!)
+      operation = ResetPassword.new(
+        utility.password_reset!.user!,
+        session: session,
+        current_login: current_login
+      )
+
       html EditPage, operation: operation
     end
 

--- a/src/shield/actions/users/edit.cr
+++ b/src/shield/actions/users/edit.cr
@@ -3,7 +3,7 @@ module Shield::Users::Edit
     skip :require_logged_out
 
     # get "/users/:user_id/edit" do
-    #   operation = UpdateUser.new(user)
+    #   operation = UpdateUser.new(user, current_login: current_login)
     #   html EditPage, operation: operation
     # end
 

--- a/src/shield/http_client.cr
+++ b/src/shield/http_client.cr
@@ -27,7 +27,8 @@ module Shield::HttpClient
 
       LogUserIn.create(
         params(email: email, password: password),
-        remote_ip: remote_ip
+        remote_ip: remote_ip,
+        session: nil
       ) do |operation, login|
         headers("Authorization": BearerToken.new(
           operation,

--- a/src/shield/operations/mixins/delete_session.cr
+++ b/src/shield/operations/mixins/delete_session.cr
@@ -1,6 +1,6 @@
 module Shield::DeleteSession
   macro included
-    needs session : Lucky::Session? = nil
+    needs session : Lucky::Session?
 
     after_commit delete_session
   end

--- a/src/shield/operations/mixins/set_session.cr
+++ b/src/shield/operations/mixins/set_session.cr
@@ -1,6 +1,6 @@
 module Shield::SetSession
   macro included
-    needs session : Lucky::Session? = nil
+    needs session : Lucky::Session?
 
     after_commit set_session
   end

--- a/src/shield/operations/mixins/update_password.cr
+++ b/src/shield/operations/mixins/update_password.cr
@@ -1,6 +1,6 @@
 module Shield::UpdatePassword
   macro included
-    needs current_login : Login? = nil
+    needs current_login : Login?
 
     before_save do
       set_password_digest


### PR DESCRIPTION
Setting default values makes it order-dependent. Arguments with default values can only appear at the end.

This makes it difficult to add new `.needs` calls after ones with default values. This may pose problems for applications that need add more `.needs` later.