### PR TITLE
Move user options columns into their own modules

### DIFF
--- a/docs/05-USER-OPTIONS.md
+++ b/docs/05-USER-OPTIONS.md
@@ -18,8 +18,6 @@
 
    `Shield::UserOptions` adds the following columns:
 
-   - `bearer_login_notify : Bool`
-   - `login_notify : Bool`
    - `password_notify : Bool`
 
    You may add other columns and associations specific to your application.
@@ -36,19 +34,11 @@
          primary_key id : Int64
 
          add_timestamps
-         add_belongs_to user : User, on_delete: :cascade
+         add_belongs_to user : User, on_delete: :cascade, unique: true
 
-         add bearer_login_notify : Bool
-         add login_notify : Bool
          add password_notify : Bool
          # ...
        end
-
-       # This sets a "UNIQUE" constraint on the foreign key (user_id)
-       execute <<-SQL
-       ALTER TABLE #{table_for(UserOptions)} ADD CONSTRAINT
-       #{table_for(UserOptions)}_user_id_unique UNIQUE (user_id);
-       SQL
      end
 
      def rollback

--- a/docs/06-LOGIN.md
+++ b/docs/06-LOGIN.md
@@ -44,7 +44,22 @@
 
    You may add other columns and associations specific to your application.
 
-1. Set up the migration:
+   ---
+   ```crystal
+   # ->>> src/models/user_options.cr
+
+   class UserOptions < BaseModel
+     # ...
+     include Shield::LoginUserOptionsColumns
+     # ...
+   end
+   ```
+
+   `Shield::LoginUserOptionsColumns` adds the following columns:
+
+   - `login_notify : Bool`
+
+1. Set up migrations:
 
    ```crystal
    # ->>> db/migrations/XXXXXXXXXXXXXX_create_logins.cr
@@ -72,6 +87,25 @@
    ```
 
    Add any columns you added to the model here.
+
+   ---
+   ```crystal
+   # ->>> db/migrations/XXXXXXXXXXXXXX_add_login_user_options.cr
+
+   class AddLoginUserOptions::VXXXXXXXXXXXXXX < Avram::Migrator::Migration::V1
+     def migrate
+       alter table_for(UserOptions) do
+         add login_notify : Bool, fill_existing_with: true
+       end
+     end
+
+     def rollback
+       alter table_for(UserOptions) do
+         remove :login_notify
+       end
+     end
+   end
+   ```
 
 1. Set up operations:
 

--- a/docs/10-BEARER-LOGIN.md
+++ b/docs/10-BEARER-LOGIN.md
@@ -72,6 +72,21 @@ This token is revoked when the user logs out.
 
    You may add other columns and associations specific to your application.
 
+   ---
+   ```crystal
+   # ->>> src/models/user_options.cr
+
+   class UserOptions < BaseModel
+     # ...
+     include Shield::BearerLoginUserOptionsColumns
+     # ...
+   end
+   ```
+
+   `Shield::BearerLoginUserOptionsColumns` adds the following columns:
+
+   - `bearer_login_notify : Bool`
+
 1. Set up the migration:
 
    ```crystal
@@ -102,6 +117,25 @@ This token is revoked when the user logs out.
    ```
 
    Add any columns you added to the model here.
+
+   ---
+   ```crystal
+   # ->>> db/migrations/XXXXXXXXXXXXXX_add_bearer_login_user_options.cr
+
+   class AddBearerLoginUserOptions::VXXXXXXXXXXXXXX < Avram::Migrator::Migration::V1
+     def migrate
+       alter table_for(UserOptions) do
+         add bearer_login_notify : Bool, fill_existing_with: true
+       end
+     end
+
+     def rollback
+       alter table_for(UserOptions) do
+         remove :bearer_login_notify
+       end
+     end
+   end
+   ```
 
 1. Set up operations:
 

--- a/spec/shield/actions/api/current_user/create_spec.cr
+++ b/spec/shield/actions/api/current_user/create_spec.cr
@@ -8,7 +8,11 @@ describe Shield::Api::CurrentUser::Create do
     response = ApiClient.exec(
       Api::RegularCurrentUser::Create,
       user: {email: email, password: password},
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.should send_json(200, {status: "success"})

--- a/spec/shield/actions/api/email_confirmation_current_user/create_spec.cr
+++ b/spec/shield/actions/api/email_confirmation_current_user/create_spec.cr
@@ -18,7 +18,11 @@ describe Shield::Api::EmailConfirmationCurrentUser::Create do
         Api::CurrentUser::Create,
         token: token,
         user: {password: password},
-        user_options: {password_notify: true, login_notify: true}
+        user_options: {
+          password_notify: true,
+          login_notify: true,
+          bearer_login_notify: true
+        }
       )
 
       response.should send_json(200, {status: "success"})
@@ -33,7 +37,11 @@ describe Shield::Api::EmailConfirmationCurrentUser::Create do
       Api::CurrentUser::Create,
       token: token,
       user: {password: password},
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.should send_json(403, {status: "failure"})
@@ -49,7 +57,11 @@ describe Shield::Api::EmailConfirmationCurrentUser::Create do
     response = client.exec(
       Api::CurrentUser::Create,
       user: {password: password},
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.should send_json(200, logged_in: true)

--- a/spec/shield/actions/api/email_confirmation_pipes_spec.cr
+++ b/spec/shield/actions/api/email_confirmation_pipes_spec.cr
@@ -17,7 +17,11 @@ describe Shield::Api::EmailConfirmationPipes do
           Api::CurrentUser::Create,
           token: token,
           user: {password: password},
-          user_options: {password_notify: true, login_notify: true}
+          user_options: {
+            password_notify: true,
+            login_notify: true,
+            bearer_login_notify: true
+          }
         )
 
         response.should send_json(200, {status: "success"})
@@ -39,7 +43,11 @@ describe Shield::Api::EmailConfirmationPipes do
           Api::CurrentUser::Create,
           token: token,
           user: {password: password},
-          user_options: {password_notify: true, login_notify: true}
+          user_options: {
+            password_notify: true,
+            login_notify: true,
+            bearer_login_notify: true
+          }
         )
 
         response.should send_json(403, ip_address_changed: true)

--- a/spec/shield/actions/api/users/create_spec.cr
+++ b/spec/shield/actions/api/users/create_spec.cr
@@ -15,7 +15,11 @@ describe Shield::Api::Users::Create do
         password: password,
         level: User::Level.new(:author).to_s
       },
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.should send_json(200, {status: "success"})
@@ -29,7 +33,11 @@ describe Shield::Api::Users::Create do
         password: "password4APASSWORD<",
         level: User::Level.new(:author).to_s
       },
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.should send_json(401, logged_in: false)

--- a/spec/shield/actions/current_user/create_spec.cr
+++ b/spec/shield/actions/current_user/create_spec.cr
@@ -8,7 +8,11 @@ describe Shield::CurrentUser::Create do
     response = ApiClient.exec(
       RegularCurrentUser::Create,
       user: {email: email, password: password},
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.status.should eq(HTTP::Status::FOUND)
@@ -26,7 +30,11 @@ describe Shield::CurrentUser::Create do
     response = client.exec(
       RegularCurrentUser::Create,
       user: {email: email, password: password},
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.status.should eq(HTTP::Status::FOUND)

--- a/spec/shield/actions/email_confirmation_current_user/create_spec.cr
+++ b/spec/shield/actions/email_confirmation_current_user/create_spec.cr
@@ -21,7 +21,11 @@ describe Shield::EmailConfirmationCurrentUser::Create do
       response = client.exec(
         CurrentUser::Create,
         user: {password: password},
-        user_options: {password_notify: true, login_notify: true}
+        user_options: {
+          password_notify: true,
+          login_notify: true,
+          bearer_login_notify: true
+        }
       )
 
       response.headers["X-User-ID"]?.should eq("ec_user_id")
@@ -40,7 +44,11 @@ describe Shield::EmailConfirmationCurrentUser::Create do
     response = client.exec(
       CurrentUser::Create,
       user: {password: password},
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.status.should eq(HTTP::Status::FOUND)
@@ -57,7 +65,11 @@ describe Shield::EmailConfirmationCurrentUser::Create do
     response = client.exec(
       CurrentUser::Create,
       user: {password: password},
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.status.should eq(HTTP::Status::FOUND)

--- a/spec/shield/actions/users/create_spec.cr
+++ b/spec/shield/actions/users/create_spec.cr
@@ -15,7 +15,11 @@ describe Shield::Users::Create do
         password: password,
         level: User::Level.new(:author).to_s
       },
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.headers["X-User-ID"]?.should eq("user_id")
@@ -32,7 +36,11 @@ describe Shield::Users::Create do
         password: password,
         level: User::Level.new(:author).to_s
       },
-      user_options: {password_notify: true, login_notify: true}
+      user_options: {
+        password_notify: true,
+        login_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     response.status.should eq(HTTP::Status::FOUND)

--- a/spec/shield/operations/mixins/create_password_spec.cr
+++ b/spec/shield/operations/mixins/create_password_spec.cr
@@ -6,7 +6,11 @@ describe Shield::CreatePassword do
 
     user = RegisterRegularCurrentUser.create!(nested_params(
       user: {email: "user@example.tld", password: password},
-      user_options: {login_notify: true, password_notify: true}
+      user_options: {
+        login_notify: true,
+        password_notify: true,
+        bearer_login_notify: true
+      }
     ))
 
     BcryptHash.new(password)
@@ -17,7 +21,11 @@ describe Shield::CreatePassword do
   it "requires password" do
     RegisterRegularCurrentUser.create(nested_params(
       user: {email: "user@domain.tld", password: ""},
-      user_options: {login_notify: true, password_notify: true}
+      user_options: {
+        login_notify: true,
+        password_notify: true,
+        bearer_login_notify: true
+      }
     )) do |operation, user|
       user.should be_nil
 
@@ -29,8 +37,14 @@ describe Shield::CreatePassword do
   it "does not send password change notification" do
     RegisterRegularCurrentUser.create(nested_params(
       user: {email: "user@domain.tld", password: "password1=Apassword"},
-      user_options: {login_notify: true, password_notify: false}
+      user_options: {
+        login_notify: true,
+        password_notify: false,
+        bearer_login_notify: true
+      }
     )) do |operation, user|
+      user.should be_a(User)
+
       PasswordChangeNotificationEmail
         .new(operation, user.not_nil!)
         .should_not(be_delivered)

--- a/spec/shield/operations/mixins/save_email_spec.cr
+++ b/spec/shield/operations/mixins/save_email_spec.cr
@@ -6,7 +6,11 @@ describe Shield::SaveEmail do
 
     user = RegisterRegularCurrentUser.create!(nested_params(
       user: {email: email, password: "password12U)password"},
-      user_options: {login_notify: true, password_notify: true}
+      user_options: {
+        login_notify: true,
+        password_notify: true,
+        bearer_login_notify: false
+      }
     ))
 
     user.email.should eq(email)

--- a/spec/shield/operations/mixins/send_welcome_email_spec.cr
+++ b/spec/shield/operations/mixins/send_welcome_email_spec.cr
@@ -9,7 +9,11 @@ describe Shield::SendWelcomeEmail do
 
     params = nested_params(
       user: {password: "password12U.password"},
-      user_options: {login_notify: true, password_notify: true}
+      user_options: {
+        login_notify: true,
+        password_notify: true,
+        bearer_login_notify: false
+      }
     )
 
     RegisterCurrentUser.create(
@@ -26,7 +30,11 @@ describe Shield::SendWelcomeEmail do
   it "sends welcome email for new user" do
     params = nested_params(
       user: {password: "password12U.password"},
-      user_options: {login_notify: true, password_notify: true}
+      user_options: {
+        login_notify: true,
+        password_notify: true,
+        bearer_login_notify: false
+      }
     )
 
     RegisterCurrentUser.create(

--- a/spec/shield/operations/mixins/validate_password_spec.cr
+++ b/spec/shield/operations/mixins/validate_password_spec.cr
@@ -25,7 +25,11 @@ describe Shield::ValidatePassword do
     Shield.temp_config(password_require_number: false) do
       RegisterRegularCurrentUser.create(nested_params(
         user: {email: "user@example.net", password: "passwordAPASSWORD-"},
-        user_options: {login_notify: true, password_notify: true}
+        user_options: {
+          login_notify: true,
+          password_notify: true,
+          bearer_login_notify: false
+        }
       )) do |operation, user|
         user.should be_a(User)
       end
@@ -46,7 +50,11 @@ describe Shield::ValidatePassword do
     Shield.temp_config(password_require_lowercase: false) do
       RegisterRegularCurrentUser.create(nested_params(
         user: {email: "user@example.org", password: "PASSWORD1AP%ASSWORD"},
-        user_options: {login_notify: true, password_notify: true}
+        user_options: {
+          login_notify: true,
+          password_notify: true,
+          bearer_login_notify: false
+        }
       )) do |operation, user|
         user.should be_a(User)
       end
@@ -67,7 +75,11 @@ describe Shield::ValidatePassword do
     Shield.temp_config(password_require_uppercase: false) do
       RegisterRegularCurrentUser.create(nested_params(
         user: {email: "user@domain.com", password: "pa(ssword1apassword"},
-        user_options: {login_notify: true, password_notify: true}
+        user_options: {
+          login_notify: true,
+          password_notify: true,
+          bearer_login_notify: false
+        }
       )) do |operation, user|
         user.should be_a(User)
       end
@@ -88,7 +100,11 @@ describe Shield::ValidatePassword do
     Shield.temp_config(password_require_special_char: false) do
       RegisterRegularCurrentUser.create(nested_params(
         user: {email: "user@domain.net", password: "password1Apassword"},
-        user_options: {login_notify: true, password_notify: true}
+        user_options: {
+          login_notify: true,
+          password_notify: true,
+          bearer_login_notify: false
+        }
       )) do |operation, user|
         user.should be_a(User)
       end

--- a/spec/shield/operations/register_email_confirmation_user_spec.cr
+++ b/spec/shield/operations/register_email_confirmation_user_spec.cr
@@ -6,7 +6,11 @@ describe Shield::RegisterEmailConfirmationUser do
 
     params = nested_params(
       user: {password: "password12U password"},
-      user_options: {login_notify: true, password_notify: true}
+      user_options: {
+        login_notify: true,
+        password_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     RegisterCurrentUser.create(
@@ -39,7 +43,11 @@ describe Shield::RegisterEmailConfirmationUser do
     user = RegisterCurrentUser.create!(
       nested_params(
         user: {password: "password12U-password"},
-        user_options: {login_notify: true, password_notify: true}
+        user_options: {
+          login_notify: true,
+          password_notify: true,
+          bearer_login_notify: true
+        }
       ),
       email_confirmation: email_confirmation,
       session: nil
@@ -62,7 +70,11 @@ describe Shield::RegisterEmailConfirmationUser do
     user = RegisterCurrentUser.create!(
       nested_params(
         user: {password: "password12U-password"},
-        user_options: {login_notify: true, password_notify: false}
+        user_options: {
+          login_notify: true,
+          password_notify: false,
+          bearer_login_notify: true
+        }
       ),
       email_confirmation: EmailConfirmationFactory.create,
       session: Lucky::Session.new,
@@ -78,7 +90,11 @@ describe Shield::RegisterEmailConfirmationUser do
     RegisterCurrentUser2.create(
       nested_params(
         user: {password: "password12U password"},
-        user_options: {login_notify: false, password_notify: false}
+        user_options: {
+          login_notify: false,
+          password_notify: false,
+          bearer_login_notify: true
+        }
       ),
       email_confirmation: EmailConfirmationFactory.create,
       session: Lucky::Session.new,

--- a/spec/shield/operations/register_user_spec.cr
+++ b/spec/shield/operations/register_user_spec.cr
@@ -8,7 +8,11 @@ describe Shield::RegisterUser do
         password: "password12U password",
         level: User::Level.new(:editor)
       },
-      user_options: {login_notify: true, password_notify: true}
+      user_options: {
+        login_notify: true,
+        password_notify: true,
+        bearer_login_notify: true
+      }
     )
 
     RegisterUser.create(params) do |operation, user|
@@ -23,7 +27,11 @@ describe Shield::RegisterUser do
         password: "password12U/password",
         level: User::Level.new(:editor)
       },
-      user_options: {login_notify: true, password_notify: false}
+      user_options: {
+        login_notify: true,
+        password_notify: false,
+        bearer_login_notify: true
+      }
     )
 
     user = RegisterUser.create!(params)
@@ -36,7 +44,11 @@ describe Shield::RegisterUser do
   it "fails when nested operation fails" do
     params = nested_params(
       user: {email: "user@example.tld", password: "password12U password"},
-      user_options: {login_notify: false, password_notify: false}
+      user_options: {
+        login_notify: false,
+        password_notify: false,
+        bearer_login_notify: true
+      }
     )
 
     RegisterRegularCurrentUser2.create(params) do |operation, user|

--- a/spec/shield/operations/save_user_options_spec.cr
+++ b/spec/shield/operations/save_user_options_spec.cr
@@ -1,6 +1,24 @@
 require "../../spec_helper"
 
 describe Shield::SaveUserOptions do
+  it "creates user options" do
+    SaveUserOptions.create(
+      params(
+        login_notify: false,
+        password_notify: true,
+        bearer_login_notify: false
+      ),
+      user_id: UserFactory.create.id
+    ) do |operation, user_options|
+      user_options.should be_a(UserOptions)
+
+      user_options = user_options.not_nil!
+
+      user_options.login_notify.should be_false
+      user_options.password_notify.should be_true
+    end
+  end
+
   it "updates user options" do
     user_options = UserOptionsFactory.create &.user_id(UserFactory.create.id)
 

--- a/spec/shield/operations/update_email_confirmation_user_spec.cr
+++ b/spec/shield/operations/update_email_confirmation_user_spec.cr
@@ -35,18 +35,25 @@ describe Shield::UpdateEmailConfirmationUser do
     user_options = UserOptionsFactory.create &.user_id(user.id)
       .login_notify(true)
       .password_notify(false)
+      .bearer_login_notify(true)
 
     UpdateCurrentUser.update(
       user,
-      nested_params(user_options: {login_notify: false, password_notify: true}),
+      nested_params(user_options: {
+        login_notify: false,
+        password_notify: true,
+        bearer_login_notify: false
+      }),
       current_login: nil,
       remote_ip: Socket::IPAddress.new("129.0.0.3", 5555)
     ) do |operation, updated_user|
       operation.saved?.should be_true
 
       user_options = updated_user.options!
+
       user_options.login_notify.should be_false
       user_options.password_notify.should be_true
+      user_options.bearer_login_notify.should be_false
     end
   end
 
@@ -56,12 +63,14 @@ describe Shield::UpdateEmailConfirmationUser do
     user_options = UserOptionsFactory.create &.user_id(user.id)
       .login_notify(true)
       .password_notify(true)
+      .bearer_login_notify(true)
 
     UpdateCurrentUser2.update(
       user,
       nested_params(user_options: {
         login_notify: false,
-        password_notify: false
+        password_notify: false,
+        bearer_login_notify: false
       }),
       current_login: nil,
       remote_ip: Socket::IPAddress.new("129.0.0.3", 5555)
@@ -83,12 +92,17 @@ describe Shield::UpdateEmailConfirmationUser do
     user_options = UserOptionsFactory.create &.user_id(user.id)
       .login_notify(true)
       .password_notify(true)
+      .bearer_login_notify(true)
 
     UpdateCurrentUser2.update(
       user,
       nested_params(
         user: {password: new_password},
-        user_options: {login_notify: false, password_notify: false}
+        user_options: {
+          login_notify: false,
+          password_notify: false,
+          bearer_login_notify: false
+        }
       ),
       current_login: nil,
       remote_ip: Socket::IPAddress.new("129.0.0.3", 5555)

--- a/spec/shield/operations/update_user_spec.cr
+++ b/spec/shield/operations/update_user_spec.cr
@@ -25,12 +25,17 @@ describe Shield::UpdateUser do
     UserOptionsFactory.create &.user_id(user.id)
       .login_notify(true)
       .password_notify(false)
+      .bearer_login_notify(true)
 
     UpdateUser.update(
       user,
       nested_params(
         user: {email: new_email},
-        user_options: {login_notify: false, password_notify: true}
+        user_options: {
+          login_notify: false,
+          password_notify: true,
+          bearer_login_notify: false
+        }
       ),
       current_login: nil
     ) do |operation, updated_user|
@@ -39,8 +44,10 @@ describe Shield::UpdateUser do
       updated_user.email.should eq(new_email)
 
       user_options = updated_user.options!
+
       user_options.login_notify.should be_false
       user_options.password_notify.should be_true
+      user_options.bearer_login_notify.should be_false
     end
   end
 
@@ -50,20 +57,24 @@ describe Shield::UpdateUser do
     UserOptionsFactory.create &.user_id(user.id)
       .login_notify(true)
       .password_notify(true)
+      .bearer_login_notify(true)
 
     UpdateRegularCurrentUser2.update(
       user,
       nested_params(user_options: {
         login_notify: false,
-        password_notify: false
+        password_notify: false,
+        bearer_login_notify: false
       }),
       current_login: nil
     ) do |operation, updated_user|
       operation.saved?.should be_false
 
       user_options = updated_user.options!
+
       user_options.login_notify.should be_true
       user_options.password_notify.should be_true
+      user_options.bearer_login_notify.should be_true
     end
   end
 
@@ -75,12 +86,17 @@ describe Shield::UpdateUser do
     UserOptionsFactory.create &.user_id(user.id)
       .login_notify(true)
       .password_notify(true)
+      .bearer_login_notify(true)
 
     UpdateRegularCurrentUser2.update(
       user,
       nested_params(
         user: {email: "user@example.com"},
-        user_options: {login_notify: false, password_notify: false}
+        user_options: {
+          login_notify: false,
+          password_notify: false,
+          bearer_login_notify: false
+        }
       ),
       current_login: nil
     ) do |operation, updated_user|

--- a/spec/support/app/db/migrations/20200625201401_create_user_options.cr
+++ b/spec/support/app/db/migrations/20200625201401_create_user_options.cr
@@ -4,16 +4,11 @@ class CreateUserOptions::V20200625201401 < Avram::Migrator::Migration::V1
       primary_key id : Int64
 
       add_timestamps
-      add_belongs_to user : User, on_delete: :cascade
+      add_belongs_to user : User, on_delete: :cascade, unique: true
 
       add login_notify : Bool
       add password_notify : Bool
     end
-
-    execute <<-SQL
-    ALTER TABLE #{table_for(UserOptions)} ADD CONSTRAINT
-    #{table_for(UserOptions)}_user_id_unique UNIQUE (user_id);
-    SQL
   end
 
   def rollback

--- a/spec/support/app/src/models/user_options.cr
+++ b/spec/support/app/src/models/user_options.cr
@@ -1,5 +1,7 @@
 class UserOptions < BaseModel
   include Shield::UserOptions
+  include Shield::LoginUserOptionsColumns
+  include Shield::BearerLoginUserOptionsColumns
 
   table :user_options {}
 end

--- a/spec/support/app/src/operations/save_user_options_2.cr
+++ b/spec/support/app/src/operations/save_user_options_2.cr
@@ -6,5 +6,6 @@ class SaveUserOptions2 < UserOptions::SaveOperation
   private def error_on_purpose
     login_notify.add_error "has failed on purpose"
     password_notify.add_error "has failed on purpose"
+    bearer_login_notify.add_error "has failed on purpose"
   end
 end

--- a/src/shield/models/mixins/bearer_login_user_options_columns.cr
+++ b/src/shield/models/mixins/bearer_login_user_options_columns.cr
@@ -1,0 +1,5 @@
+module Shield::BearerLoginUserOptionsColumns
+  macro included
+    column bearer_login_notify : Bool
+  end
+end

--- a/src/shield/models/mixins/login_user_options_columns.cr
+++ b/src/shield/models/mixins/login_user_options_columns.cr
@@ -1,0 +1,5 @@
+module Shield::LoginUserOptionsColumns
+  macro included
+    column login_notify : Bool
+  end
+end

--- a/src/shield/models/user_options.cr
+++ b/src/shield/models/user_options.cr
@@ -2,8 +2,6 @@ module Shield::UserOptions
   macro included
     include Shield::BelongsToUser
 
-    column bearer_login_notify : Bool
-    column login_notify : Bool
     column password_notify : Bool
   end
 end

--- a/src/shield/operations/save_user_options.cr
+++ b/src/shield/operations/save_user_options.cr
@@ -3,15 +3,8 @@ module Shield::SaveUserOptions
     permit_columns :password_notify
 
     before_save do
-      set_unused_columns
-
       validate_required password_notify, user_id
       validate_primary_key user_id, query: UserQuery
-    end
-
-    private def set_unused_columns
-      login_notify.value = false if login_notify.value.nil?
-      bearer_login_notify.value = false if bearer_login_notify.value.nil?
     end
   end
 end


### PR DESCRIPTION
Allows adding columns only if the corresponding models are used.