### PR TITLE
Refactor `.table_for` macro

### DIFF
--- a/src/charms.cr
+++ b/src/charms.cr
@@ -176,6 +176,96 @@ module Avram
     end
   end
 
+  # See https://github.com/luckyframework/avram/issues/638
+  module TableFor
+    macro table_for(model)
+      {{ model }}::TABLE_NAME
+    end
+  end
+
+  # See https://github.com/luckyframework/avram/issues/638
+  module Migrator
+    class AlterTableStatement
+      macro add_belongs_to(
+        type_declaration,
+        on_delete,
+        references = nil,
+        foreign_key_type = Int64,
+        fill_existing_with = nil,
+        unique = false
+      )
+        {% unless type_declaration.is_a?(TypeDeclaration) %}
+          {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
+        {% end %}
+
+        {% optional = type_declaration.type.is_a?(Union) %}
+
+        {% if optional %}
+          {% type = type_declaration.type.types.first %}
+        {% else %}
+          {% type = type_declaration.type %}
+        {% end %}
+
+        {% foreign_key_name = type_declaration.var + "_id" %}
+        %table_name = {{ references }} || table_for({{ type }})
+
+        rows << ::Avram::Migrator::Columns::{{ foreign_key_type }}Column({{ foreign_key_type }}).new(
+          name: {{ foreign_key_name.stringify }},
+          nilable: {{ optional }},
+          default: nil
+        )
+        .set_references(references: %table_name.to_s, on_delete: {{ on_delete }})
+        .build_add_statement_for_alter
+
+        {% if fill_existing_with && fill_existing_with != :nothing %}
+          add_fill_existing_with_statements(
+            column: {{ foreign_key_name.stringify }},
+            type: {{ foreign_key_type }},
+            value: Avram::Migrator::Columns::{{ foreign_key_type }}Column.prepare_value_for_database({{ fill_existing_with }}),
+            nilable: {{ optional }}
+          )
+        {% end %}
+
+        add_index :{{ foreign_key_name }}, unique: {{ unique }}
+      end
+    end
+
+    class CreateTableStatement
+      macro add_belongs_to(
+        type_declaration,
+        on_delete,
+        references = nil,
+        foreign_key_type = Int64,
+        unique = false
+      )
+        {% unless type_declaration.is_a?(TypeDeclaration) %}
+          {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
+        {% end %}
+
+        {% optional = type_declaration.type.is_a?(Union) %}
+
+        {% if optional %}
+          {% type = type_declaration.type.types.first %}
+        {% else %}
+          {% type = type_declaration.type %}
+        {% end %}
+
+        {% foreign_key_name = type_declaration.var + "_id" %}
+        %table_name = {{ references }} || table_for({{ type }})
+
+        rows << Avram::Migrator::Columns::{{ foreign_key_type }}Column({{ foreign_key_type }}).new(
+          name: {{ foreign_key_name.stringify }},
+          nilable: {{ optional }},
+          default: nil,
+        )
+        .set_references(references: %table_name.to_s, on_delete: {{ on_delete }})
+        .build_add_statement_for_create
+
+        add_index :{{ foreign_key_name }}, unique: {{ unique }}
+      end
+    end
+  end
+
   module Validations
     def validate_email(
       *attributes,


### PR DESCRIPTION
Refactored to return the name set by the model's `.table` macro. This keeps things DRY, and makes the model the single source of
truth.