### PR TITLE
Undo `skip_default_columns` in `Shield::AuthenticationColumns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Require email columns to be case-insensitive.
 - Save login notification option only when `Login` model is active.
 - Rename `DeleteLogin` to `DeleteCurrentLogin`.
+- Undo `skip_default_columns` in `Shield::AuthenticationColumns`
 
 ### Removed
 - Remove support for *Lucky* v0.25.

--- a/docs/06-LOGIN.md
+++ b/docs/06-LOGIN.md
@@ -70,6 +70,7 @@
          # ...
          primary_key id : Int64
 
+         add_timestamps
          add_belongs_to user : User, on_delete: :cascade
 
          add token_digest : String

--- a/docs/07-PASSWORD-RESET.md
+++ b/docs/07-PASSWORD-RESET.md
@@ -52,6 +52,7 @@
          # ...
          primary_key id : Int64
 
+         add_timestamps
          add_belongs_to user : User, on_delete: :cascade
 
          add token_digest : String

--- a/docs/09-EMAIL-CONFIRMATION.md
+++ b/docs/09-EMAIL-CONFIRMATION.md
@@ -64,6 +64,7 @@ This is particularly important, since email addresses are usually the only means
          # ...
          primary_key id : Int64
 
+         add_timestamps
          add_belongs_to user : User?, on_delete: :cascade
 
          add email : String, case_sensitive: false

--- a/docs/10-BEARER-LOGIN.md
+++ b/docs/10-BEARER-LOGIN.md
@@ -98,6 +98,7 @@ This token is revoked when the user logs out.
          # ...
          primary_key id : Int64
 
+         add_timestamps
          add_belongs_to user : User, on_delete: :cascade
 
          add name : String

--- a/spec/support/app/src/models/bearer_login.cr
+++ b/spec/support/app/src/models/bearer_login.cr
@@ -1,5 +1,8 @@
 class BearerLogin < BaseModel
   include Shield::BearerLogin
 
+  skip_default_columns
+  primary_key id : Int64
+
   table :bearer_logins {}
 end

--- a/spec/support/app/src/models/email_confirmation.cr
+++ b/spec/support/app/src/models/email_confirmation.cr
@@ -1,5 +1,8 @@
 class EmailConfirmation < BaseModel
   include Shield::EmailConfirmation
 
+  skip_default_columns
+  primary_key id : Int64
+
   table :email_confirmations {}
 end

--- a/spec/support/app/src/models/login.cr
+++ b/spec/support/app/src/models/login.cr
@@ -1,5 +1,8 @@
 class Login < BaseModel
   include Shield::Login
 
+  skip_default_columns
+  primary_key id : Int64
+
   table :logins {}
 end

--- a/spec/support/app/src/models/password_reset.cr
+++ b/spec/support/app/src/models/password_reset.cr
@@ -1,5 +1,8 @@
 class PasswordReset < BaseModel
   include Shield::PasswordReset
 
+  skip_default_columns
+  primary_key id : Int64
+
   table :password_resets {}
 end

--- a/src/shield/models/mixins/authentication_columns.cr
+++ b/src/shield/models/mixins/authentication_columns.cr
@@ -2,9 +2,6 @@ module Shield::AuthenticationColumns
   macro included
     include Shield::StatusColumns
 
-    skip_default_columns
-    primary_key id : Int64
-
     column token_digest : String
   end
 end


### PR DESCRIPTION
This is a decision every app developer should make for themselves.