### PR TITLE
Rename *bang* methods to their respective non-bang equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for *Lucky* v0.28
 
+### Changed
+- Rename *bang* counterparts of nilable methods to their non-bang equivalents
+- Append `?` to names of methods with nilable return values
+
 ### Fixed
 - Avoid making queries in validations if operation already invalid
 

--- a/docs/04-USER.md
+++ b/docs/04-USER.md
@@ -179,7 +179,7 @@
      include Shield::CurrentUser::Edit
 
      get "/account/edit" do
-       operation = UpdateCurrentUser.new(user, current_login: current_login)
+       operation = UpdateCurrentUser.new(user, current_login: current_login?)
        html EditPage, operation: operation
      end
      # ...

--- a/docs/06-LOGIN.md
+++ b/docs/06-LOGIN.md
@@ -220,7 +220,7 @@
      include Shield::CurrentLogin::New
 
      get "/login" do
-       operation = LogUserIn.new(remote_ip: remote_ip, session: session)
+       operation = LogUserIn.new(remote_ip: remote_ip?, session: session)
        html NewPage, operation: operation
      end
      # ...

--- a/docs/07-PASSWORD-RESET.md
+++ b/docs/07-PASSWORD-RESET.md
@@ -171,7 +171,7 @@
      include Shield::PasswordResets::New
 
      get "/password-resets/new" do
-       operation = StartPasswordReset.new(remote_ip: remote_ip)
+       operation = StartPasswordReset.new(remote_ip: remote_ip?)
        html NewPage, operation: operation
      end
      # ...

--- a/docs/09-EMAIL-CONFIRMATION.md
+++ b/docs/09-EMAIL-CONFIRMATION.md
@@ -225,7 +225,7 @@ This is particularly important, since email addresses are usually the only means
      include Shield::EmailConfirmations::New
 
      get "/email-confirmations/new" do
-       operation = StartEmailConfirmation.new(remote_ip: remote_ip)
+       operation = StartEmailConfirmation.new(remote_ip: remote_ip?)
        html NewPage, operation: operation
      end
      # ...
@@ -465,8 +465,8 @@ This is particularly important, since email addresses are usually the only means
      get "/account/edit" do
        operation = UpdateCurrentUser.new(
          user,
-         remote_ip: remote_ip,
-         current_login: current_login
+         remote_ip: remote_ip?,
+         current_login: current_login?
        )
 
        html EditPage, operation: operation

--- a/docs/10-BEARER-LOGIN.md
+++ b/docs/10-BEARER-LOGIN.md
@@ -420,10 +420,10 @@ This token is revoked when the user logs out.
 
 - `#bearer_logged_in?`
 - `#bearer_logged_out?`
+- `#current_bearer_login?`
 - `#current_bearer_login`
-- `#current_bearer_login!`
+- `#current_bearer_user?`
 - `#current_bearer_user`
-- `#current_bearer_user!`
 
 Other helpers are provided as follows:
 

--- a/docs/11-ACTION-HELPERS.md
+++ b/docs/11-ACTION-HELPERS.md
@@ -2,21 +2,21 @@
 
 *Shield* comes with the following action helpers:
 
-- `#current_login`:
+- `#current_login?`:
 
   Returns the current login, or `nil` if the user is not logged in.
 
-- `#current_login!`:
+- `#current_login`:
 
-   Equivalent to `current_login.not_nil!`.
+   Equivalent to `current_login?.not_nil!`.
 
-- `#current_user`:
+- `#current_user?`:
 
   Returns the current logged-in user, or `nil` if the user is not logged in.
 
-- `#current_user!`:
+- `#current_user`:
 
-  Equivalent to `current_user.not_nil!`.
+  Equivalent to `current_user?.not_nil!`.
 
 - `#logged_in?`:
 
@@ -26,14 +26,26 @@
 
   Returns true if current user is **not** logged in. It is the inverse of `#logged_in?`
 
-- `#previous_page_url`:
+- `#previous_page_url?`:
 
   Returns the previous page URL, retrieved from session rather than from request headers.
 
-- `#remote_ip`:
+- `#previous_page_url`:
+
+  Equivalent to `previous_page_url?.not_nil!`.
+
+- `#remote_ip?`:
 
   Returns the client's IP address as `Socket::IPAddress?`.
 
-- `#return_url`:
+- `#remote_ip`:
+
+  Equivalent to `remote_ip?.not_nil!`.
+
+- `#return_url?`:
 
   Returns the URL to redirect back to, retrieved from session.
+
+- `#return_url`:
+
+  Equivalent to `return_url?.not_nil!`.

--- a/spec/shield/actions/email_confirmations/show_spec.cr
+++ b/spec/shield/actions/email_confirmations/show_spec.cr
@@ -19,8 +19,8 @@ describe Shield::EmailConfirmations::Show do
 
       from_session = EmailConfirmationSession.new(session)
 
-      from_session.email_confirmation_id.should(eq email_confirmation.id)
-      from_session.email_confirmation_token.should eq(operation.token)
+      from_session.email_confirmation_id?.should(eq email_confirmation.id)
+      from_session.email_confirmation_token?.should eq(operation.token)
     end
   end
 end

--- a/spec/shield/actions/password_resets/show_spec.cr
+++ b/spec/shield/actions/password_resets/show_spec.cr
@@ -25,12 +25,12 @@ describe Shield::PasswordResets::Show do
 
       PasswordResetSession
         .new(session)
-        .password_reset_id
+        .password_reset_id?
         .should eq(password_reset.id)
 
       PasswordResetSession
         .new(session)
-        .password_reset_token
+        .password_reset_token?
         .should eq(operation.token)
     end
   end

--- a/spec/shield/operations/end_email_confirmation_spec.cr
+++ b/spec/shield/operations/end_email_confirmation_spec.cr
@@ -24,7 +24,10 @@ describe Shield::EndEmailConfirmation do
       end
     end
 
-    EmailConfirmationSession.new(session).email_confirmation_id.should be_nil
-    EmailConfirmationSession.new(session).email_confirmation_token.should be_nil
+    EmailConfirmationSession.new(session).email_confirmation_id?.should be_nil
+
+    EmailConfirmationSession.new(session)
+      .email_confirmation_token?
+      .should(be_nil)
   end
 end

--- a/spec/shield/operations/end_password_reset_spec.cr
+++ b/spec/shield/operations/end_password_reset_spec.cr
@@ -28,7 +28,7 @@ describe Shield::EndPasswordReset do
       end
     end
 
-    PasswordResetSession.new(session).password_reset_id.should be_nil
-    PasswordResetSession.new(session).password_reset_token.should be_nil
+    PasswordResetSession.new(session).password_reset_id?.should be_nil
+    PasswordResetSession.new(session).password_reset_token?.should be_nil
   end
 end

--- a/spec/shield/operations/log_user_in_spec.cr
+++ b/spec/shield/operations/log_user_in_spec.cr
@@ -20,8 +20,8 @@ describe Shield::LogUserIn do
     login.active?.should be_true
     login.ip_address.should eq(ip_address.address)
 
-    LoginSession.new(session).login_id!.should eq(login.id)
-    LoginSession.new(session).login_token!.should_not be_empty
+    LoginSession.new(session).login_id.should eq(login.id)
+    LoginSession.new(session).login_token.should_not be_empty
   end
 
   it "requires valid IP address" do

--- a/spec/shield/operations/log_user_out_spec.cr
+++ b/spec/shield/operations/log_user_out_spec.cr
@@ -16,18 +16,18 @@ describe Shield::LogUserOut do
       remote_ip: Socket::IPAddress.new("0.0.0.0", 0)
     )
 
-    LoginSession.new(session).login_id.should_not be_nil
+    LoginSession.new(session).login_id?.should_not be_nil
 
     login.active?.should be_true
 
     LogUserOut.update(
-      LoginSession.new(session).login!,
+      LoginSession.new(session).login,
       session: session
     ) do |operation, updated_login|
       operation.saved?.should be_true
 
       updated_login.active?.should be_false
-      LoginSession.new(session).login_id.should be_nil
+      LoginSession.new(session).login_id?.should be_nil
     end
   end
 end

--- a/spec/shield/operations/reset_password_spec.cr
+++ b/spec/shield/operations/reset_password_spec.cr
@@ -31,8 +31,8 @@ describe Shield::ResetPassword do
           .should(be_a User)
 
         password_reset.reload.active?.should be_false
-        PasswordResetSession.new(session).password_reset_id.should be_nil
-        PasswordResetSession.new(session).password_reset_token.should be_nil
+        PasswordResetSession.new(session).password_reset_id?.should be_nil
+        PasswordResetSession.new(session).password_reset_token?.should be_nil
       end
     end
   end

--- a/spec/shield/operations/update_confirmed_email_spec.cr
+++ b/spec/shield/operations/update_confirmed_email_spec.cr
@@ -22,15 +22,15 @@ describe Shield::UpdateConfirmedEmail do
 
       UpdateConfirmedEmail.update(
         from_session.verify!.user!.not_nil!,
-        email_confirmation: from_session.email_confirmation!,
+        email_confirmation: from_session.email_confirmation,
         session: session
       ) do |operation, updated_user|
         operation.saved?.should be_true
 
         user.reload.email = new_email
 
-        from_session.email_confirmation_id.should be_nil
-        from_session.email_confirmation_token.should be_nil
+        from_session.email_confirmation_id?.should be_nil
+        from_session.email_confirmation_token?.should be_nil
       end
     end
   end

--- a/spec/shield/utilities/mixins/bearer_token_spec.cr
+++ b/spec/shield/utilities/mixins/bearer_token_spec.cr
@@ -18,7 +18,7 @@ describe Shield::BearerToken do
       ]
 
       all_headers.each do |headers|
-        BearerToken.from_headers(headers).should be_a(BearerToken)
+        BearerToken.from_headers?(headers).should be_a(BearerToken)
       end
     end
 
@@ -31,7 +31,7 @@ describe Shield::BearerToken do
       ]
 
       all_headers.each do |headers|
-        BearerToken.from_headers(headers).should be_nil
+        BearerToken.from_headers?(headers).should be_nil
       end
     end
   end

--- a/spec/support/app/src/actions/about/index.cr
+++ b/spec/support/app/src/actions/about/index.cr
@@ -3,6 +3,6 @@ class About::Index < BrowserAction
   skip :require_logged_out
 
   get "/about" do
-    json({page: "About::Index", previous_page: previous_page_url})
+    json({page: "About::Index", previous_page: previous_page_url?})
   end
 end

--- a/spec/support/app/src/actions/about/new.cr
+++ b/spec/support/app/src/actions/about/new.cr
@@ -1,5 +1,5 @@
 class About::New < BrowserAction
   get "/about/new" do
-    json({page: "About::New", session: LoginSession.new(session).login_id})
+    json({page: "About::New", session: LoginSession.new(session).login_id?})
   end
 end

--- a/spec/support/app/src/actions/api/current_login/create.cr
+++ b/spec/support/app/src/actions/api/current_login/create.cr
@@ -6,7 +6,7 @@ class Api::CurrentLogin::Create < ApiAction
     run_operation
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/api/current_login/delete.cr
+++ b/spec/support/app/src/actions/api/current_login/delete.cr
@@ -5,7 +5,7 @@ class Api::CurrentLogin::Delete < ApiAction
     run_operation
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/api/current_login/destroy.cr
+++ b/spec/support/app/src/actions/api/current_login/destroy.cr
@@ -5,7 +5,7 @@ class Api::CurrentLogin::Destroy < ApiAction
     run_operation
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/api/current_user/create.cr
+++ b/spec/support/app/src/actions/api/current_user/create.cr
@@ -5,7 +5,7 @@ class Api::CurrentUser::Create < ApiAction
     run_operation
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/api/password_resets/update.cr
+++ b/spec/support/app/src/actions/api/password_resets/update.cr
@@ -5,7 +5,7 @@ class Api::PasswordResets::Update < ApiAction
     run_operation
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/api/posts/create.cr
+++ b/spec/support/app/src/actions/api/posts/create.cr
@@ -4,9 +4,9 @@ class Api::Posts::Create < ApiAction
 
   post "/posts" do
     json({
-      scopes: current_bearer_login.try &.scopes,
-      current_bearer_user: current_bearer_user.try &.id,
-      current_user: current_user.try &.id
+      scopes: current_bearer_login?.try &.scopes,
+      current_bearer_user: current_bearer_user?.try &.id,
+      current_user: current_user?.try &.id
     })
   end
 end

--- a/spec/support/app/src/actions/api/posts/index.cr
+++ b/spec/support/app/src/actions/api/posts/index.cr
@@ -3,9 +3,9 @@ class Api::Posts::Index < ApiAction
 
   get "/posts" do
     json({
-      scopes: current_bearer_login.try &.scopes,
-      current_bearer_user: current_bearer_user.try &.id,
-      current_user: current_user.try &.id
+      scopes: current_bearer_login?.try &.scopes,
+      current_bearer_user: current_bearer_user?.try &.id,
+      current_user: current_user?.try &.id
     })
   end
 
@@ -13,7 +13,7 @@ class Api::Posts::Index < ApiAction
     true
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/api/posts/new.cr
+++ b/spec/support/app/src/actions/api/posts/new.cr
@@ -3,9 +3,9 @@ class Api::Posts::New < ApiAction
 
   get "/posts/new" do
     json({
-      scopes: current_bearer_login.try &.scopes,
-      current_bearer_user: current_bearer_user.try &.id,
-      current_user: current_user.try &.id
+      scopes: current_bearer_login?.try &.scopes,
+      current_bearer_user: current_bearer_user?.try &.id,
+      current_user: current_user?.try &.id
     })
   end
 

--- a/spec/support/app/src/actions/api/regular_current_user/update.cr
+++ b/spec/support/app/src/actions/api/regular_current_user/update.cr
@@ -11,7 +11,7 @@ class Api::RegularCurrentUser::Update < ApiAction
     UpdateRegularCurrentUser.update(
       user,
       params,
-      current_login: current_login
+      current_login: current_login?
     ) do |operation, updated_user|
       if operation.saved?
         do_run_operation_succeeded(operation, updated_user)

--- a/spec/support/app/src/actions/current_login/create.cr
+++ b/spec/support/app/src/actions/current_login/create.cr
@@ -7,13 +7,13 @@ class CurrentLogin::Create < BrowserAction
   end
 
   def do_run_operation_succeeded(operation, login)
-    response.headers["X-Login-ID"] = current_login!.id.to_s
+    response.headers["X-Login-ID"] = current_login.id.to_s
     response.headers["X-Login-Token"] = operation.token
-    response.headers["X-User-ID"] = current_user!.id.to_s
+    response.headers["X-User-ID"] = current_user.id.to_s
     previous_def
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/current_login/delete.cr
+++ b/spec/support/app/src/actions/current_login/delete.cr
@@ -10,7 +10,7 @@ class CurrentLogin::Delete < BrowserAction
     previous_def
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/current_login/destroy.cr
+++ b/spec/support/app/src/actions/current_login/destroy.cr
@@ -10,7 +10,7 @@ class CurrentLogin::Destroy < BrowserAction
     previous_def
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/current_login/new.cr
+++ b/spec/support/app/src/actions/current_login/new.cr
@@ -2,7 +2,7 @@ class CurrentLogin::New < BrowserAction
   include Shield::CurrentLogin::New
 
   get "/log-in" do
-    operation = LogUserIn.new(remote_ip: remote_ip, session: session)
+    operation = LogUserIn.new(remote_ip: remote_ip?, session: session)
     html NewPage, operation: operation
   end
 end

--- a/spec/support/app/src/actions/current_user/edit.cr
+++ b/spec/support/app/src/actions/current_user/edit.cr
@@ -6,8 +6,8 @@ class CurrentUser::Edit < BrowserAction
   get "/ec/profile/edit" do
     operation = UpdateCurrentUser.new(
       user,
-      remote_ip: remote_ip,
-      current_login: current_login
+      remote_ip: remote_ip?,
+      current_login: current_login?
     )
 
     html EditPage, operation: operation

--- a/spec/support/app/src/actions/current_user/new.cr
+++ b/spec/support/app/src/actions/current_user/new.cr
@@ -10,7 +10,7 @@ class CurrentUser::New < BrowserAction
     previous_def
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/spec/support/app/src/actions/email_confirmations/new.cr
+++ b/spec/support/app/src/actions/email_confirmations/new.cr
@@ -2,7 +2,7 @@ class EmailConfirmations::New < BrowserAction
   include Shield::EmailConfirmations::New
 
   get "/email-confirmations/new" do
-    operation = StartEmailConfirmation.new(remote_ip: remote_ip)
+    operation = StartEmailConfirmation.new(remote_ip: remote_ip?)
     html NewPage, operation: operation
   end
 end

--- a/spec/support/app/src/actions/home/create.cr
+++ b/spec/support/app/src/actions/home/create.cr
@@ -3,6 +3,6 @@ class Home::Create < BrowserAction
   skip :require_logged_out
 
   post "/" do
-    json({page: "Home::Create", previous_page: previous_page_url})
+    json({page: "Home::Create", previous_page: previous_page_url?})
   end
 end

--- a/spec/support/app/src/actions/home/index.cr
+++ b/spec/support/app/src/actions/home/index.cr
@@ -3,6 +3,6 @@ class Home::Index < BrowserAction
   skip :require_logged_out
 
   get "/" do
-    json({page: "Home::Index", previous_page: previous_page_url})
+    json({page: "Home::Index", previous_page: previous_page_url?})
   end
 end

--- a/spec/support/app/src/actions/password_resets/edit.cr
+++ b/spec/support/app/src/actions/password_resets/edit.cr
@@ -5,7 +5,7 @@ class PasswordResets::Edit < BrowserAction
     run_operation
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 

--- a/spec/support/app/src/actions/password_resets/new.cr
+++ b/spec/support/app/src/actions/password_resets/new.cr
@@ -2,7 +2,7 @@ class PasswordResets::New < BrowserAction
   include Shield::PasswordResets::New
 
   get "/password-resets/new" do
-    operation = StartPasswordReset.new(remote_ip: remote_ip)
+    operation = StartPasswordReset.new(remote_ip: remote_ip?)
     html NewPage, operation: operation
   end
 end

--- a/spec/support/app/src/actions/password_resets/update.cr
+++ b/spec/support/app/src/actions/password_resets/update.cr
@@ -10,7 +10,7 @@ class PasswordResets::Update < BrowserAction
     previous_def
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("129.0.0.5", 6000)
   end
 end

--- a/spec/support/app/src/actions/regular_current_user/edit.cr
+++ b/spec/support/app/src/actions/regular_current_user/edit.cr
@@ -4,7 +4,11 @@ class RegularCurrentUser::Edit < BrowserAction
   skip :pin_login_to_ip_address
 
   get "/profile/edit" do
-    operation = UpdateRegularCurrentUser.new(user, current_login: current_login)
+    operation = UpdateRegularCurrentUser.new(
+      user,
+      current_login: current_login?
+    )
+
     html EditPage, operation: operation
   end
 end

--- a/spec/support/app/src/actions/regular_current_user/update.cr
+++ b/spec/support/app/src/actions/regular_current_user/update.cr
@@ -11,7 +11,7 @@ class RegularCurrentUser::Update < BrowserAction
     UpdateRegularCurrentUser.update(
       user,
       params,
-      current_login: current_login
+      current_login: current_login?
     ) do |operation, updated_user|
       if operation.saved?
         do_run_operation_succeeded(operation, updated_user)

--- a/spec/support/app/src/actions/users/edit.cr
+++ b/spec/support/app/src/actions/users/edit.cr
@@ -4,11 +4,11 @@ class Users::Edit < BrowserAction
   skip :check_authorization
 
   get "/users/:user_id/edit" do
-    operation = UpdateUser.new(user, current_login: current_login)
+    operation = UpdateUser.new(user, current_login: current_login?)
     html EditPage, operation: operation
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("129.0.0.5", 6000)
   end
 end

--- a/spec/support/app/src/actions/users/show.cr
+++ b/spec/support/app/src/actions/users/show.cr
@@ -7,7 +7,7 @@ class Users::Show < BrowserAction
     html ShowPage, user: user
   end
 
-  def remote_ip : Socket::IPAddress?
+  def remote_ip? : Socket::IPAddress?
     Socket::IPAddress.new("128.0.0.2", 5000)
   end
 end

--- a/src/charms.cr
+++ b/src/charms.cr
@@ -123,30 +123,16 @@ module Lucky
 end
 
 module Avram
-  class Attribute(T)
-    def value!
-      value.not_nil!
-    end
-  end
-
   abstract class Operation
     include MailHelpers
   end
 
   abstract class DeleteOperation(T)
     include MailHelpers
-
-    def record!
-      record.not_nil!
-    end
   end
 
   abstract class SaveOperation(T)
     include MailHelpers
-
-    def record!
-      record.not_nil!
-    end
 
     # Getting rid of default validations in Avram
     #

--- a/src/shield/actions/action_helpers.cr
+++ b/src/shield/actions/action_helpers.cr
@@ -1,6 +1,10 @@
 module Shield::ActionHelpers
   macro included
-    def remote_ip : Socket::IPAddress?
+    def remote_ip : Socket::IPAddress
+      remote_ip?.not_nil!
+    end
+
+    def remote_ip? : Socket::IPAddress?
       request.remote_address.as(Socket::IPAddress)
     rescue
     end

--- a/src/shield/actions/action_pipes.cr
+++ b/src/shield/actions/action_pipes.cr
@@ -7,12 +7,20 @@ module Shield::ActionPipes
       continue
     end
 
-    getter previous_page_url : String? do
-      PageUrlSession.new(session).previous_page_url
+    def previous_page_url
+      previous_page_url?.not_nil!
     end
 
-    getter return_url : String? do
-      ReturnUrlSession.new(session).return_url
+    getter? previous_page_url : String? do
+      PageUrlSession.new(session).previous_page_url?
+    end
+
+    def return_url
+      return_url?.not_nil!
+    end
+
+    getter? return_url : String? do
+      ReturnUrlSession.new(session).return_url?
     end
 
     def redirect_back(
@@ -22,9 +30,9 @@ module Shield::ActionPipes
       allow_external : Bool = false
     )
       if request.method.in?({"PATCH", "POST", "PUT"})
-        url = return_url || fallback
+        url = return_url? || fallback
       else
-        url = return_url || previous_page_url || fallback
+        url = return_url? || previous_page_url? || fallback
       end
 
       redirect to: url, status: status

--- a/src/shield/actions/api/authorization_pipes.cr
+++ b/src/shield/actions/api/authorization_pipes.cr
@@ -7,9 +7,9 @@ module Shield::Api::AuthorizationPipes
     def check_authorization
       if logged_out? && bearer_logged_out?
         continue
-      elsif logged_in? && authorize?(current_user!)
+      elsif logged_in? && authorize?(current_user)
         continue
-      elsif authorize_bearer_login? && authorize?(current_bearer_user!)
+      elsif authorize_bearer_login? && authorize?(current_bearer_user)
         continue
       else
         send_insufficient_scope_response
@@ -25,7 +25,7 @@ module Shield::Api::AuthorizationPipes
     end
 
     private def authorize_bearer_login?
-      current_bearer_login.try &.scopes.includes?(bearer_scope)
+      current_bearer_login?.try &.scopes.includes?(bearer_scope)
     end
 
     private def send_insufficient_scope_response

--- a/src/shield/actions/api/bearer_logins/create.cr
+++ b/src/shield/actions/api/bearer_logins/create.cr
@@ -22,7 +22,7 @@ module Shield::Api::BearerLogins::Create
     end
 
     def user
-      current_or_bearer_user!
+      current_or_bearer_user
     end
 
     def do_run_operation_succeeded(operation, bearer_login)

--- a/src/shield/actions/api/bearer_logins/index.cr
+++ b/src/shield/actions/api/bearer_logins/index.cr
@@ -33,7 +33,7 @@ module Shield::Api::BearerLogins::Index
     end
 
     def user
-      current_or_bearer_user!
+      current_or_bearer_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/api/current_login/create.cr
+++ b/src/shield/actions/api/current_login/create.cr
@@ -9,7 +9,7 @@ module Shield::Api::CurrentLogin::Create
     def run_operation
       LogUserIn.create(
         params,
-        remote_ip: remote_ip,
+        remote_ip: remote_ip?,
         session: nil
       ) do |operation, login|
         if login

--- a/src/shield/actions/api/current_login/destroy.cr
+++ b/src/shield/actions/api/current_login/destroy.cr
@@ -17,7 +17,7 @@ module Shield::Api::CurrentLogin::Destroy
     end
 
     def login
-      current_login!
+      current_login
     end
 
     def do_run_operation_succeeded(operation, login)

--- a/src/shield/actions/api/current_user/show.cr
+++ b/src/shield/actions/api/current_user/show.cr
@@ -10,7 +10,7 @@ module Shield::Api::CurrentUser::Show
     # end
 
     def user
-      current_or_bearer_user!
+      current_or_bearer_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/api/current_user/update.cr
+++ b/src/shield/actions/api/current_user/update.cr
@@ -10,7 +10,7 @@ module Shield::Api::CurrentUser::Update
       UpdateCurrentUser.update(
         user,
         params,
-        current_login: current_login
+        current_login: current_login?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)
@@ -21,7 +21,7 @@ module Shield::Api::CurrentUser::Update
     end
 
     def user
-      current_or_bearer_user!
+      current_or_bearer_user
     end
 
     def do_run_operation_succeeded(operation, user)

--- a/src/shield/actions/api/email_confirmation_current_user/update.cr
+++ b/src/shield/actions/api/email_confirmation_current_user/update.cr
@@ -10,8 +10,8 @@ module Shield::Api::EmailConfirmationCurrentUser::Update
       UpdateCurrentUser.update(
         user,
         params,
-        current_login: current_login,
-        remote_ip: remote_ip
+        current_login: current_login?,
+        remote_ip: remote_ip?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)

--- a/src/shield/actions/api/email_confirmation_pipes.cr
+++ b/src/shield/actions/api/email_confirmation_pipes.cr
@@ -4,11 +4,11 @@ module Shield::Api::EmailConfirmationPipes
 
     def pin_email_confirmation_to_ip_address
       email_confirmation_params = EmailConfirmationParams.new(params)
-      email_confirmation = email_confirmation_params.email_confirmation
+      email_confirmation = email_confirmation_params.email_confirmation?
 
       if email_confirmation.nil? ||
         !email_confirmation.not_nil!.active? ||
-        email_confirmation.not_nil!.ip_address == remote_ip.try &.address
+        email_confirmation.not_nil!.ip_address == remote_ip?.try &.address
         continue
       else
         EndEmailConfirmation.update!(email_confirmation.not_nil!, session: nil)

--- a/src/shield/actions/api/email_confirmations/create.cr
+++ b/src/shield/actions/api/email_confirmations/create.cr
@@ -13,7 +13,7 @@ module Shield::Api::EmailConfirmations::Create
     def run_operation
       StartEmailConfirmation.create(
         params,
-        remote_ip: remote_ip
+        remote_ip: remote_ip?
       ) do |operation, email_confirmation|
         if email_confirmation
           do_run_operation_succeeded(operation, email_confirmation.not_nil!)

--- a/src/shield/actions/api/email_confirmations/edit.cr
+++ b/src/shield/actions/api/email_confirmations/edit.cr
@@ -35,7 +35,7 @@ module Shield::Api::EmailConfirmations::Edit
     end
 
     def user
-      current_or_bearer_user!
+      current_or_bearer_user
     end
 
     def do_verify_operation_failed(utility)

--- a/src/shield/actions/api/login_helpers.cr
+++ b/src/shield/actions/api/login_helpers.cr
@@ -2,16 +2,20 @@ module Shield::Api::LoginHelpers
   macro included
     include Shield::LoginHelpers
 
-    getter current_login : Login? do
+    def current_login
+      current_login?.not_nil!
+    end
+
+    getter? current_login : Login? do
       LoginHeaders.new(request.headers).verify
     end
 
-    def current_or_bearer_user! : User
-      current_or_bearer_user.not_nil!
+    def current_or_bearer_user
+      current_or_bearer_user?.not_nil!
     end
 
-    def current_or_bearer_user : User?
-      current_user || current_bearer_user
+    getter? current_or_bearer_user : User? do
+      current_user? || current_bearer_user?
     end
 
     def bearer_logged_in? : Bool
@@ -19,22 +23,22 @@ module Shield::Api::LoginHelpers
     end
 
     def bearer_logged_out? : Bool
-      current_bearer_user.nil?
+      current_bearer_user?.nil?
     end
 
-    def current_bearer_user! : User
-      current_bearer_user.not_nil!
+    def current_bearer_user
+      current_bearer_user?.not_nil!
     end
 
-    getter current_bearer_user : User? do
-      current_bearer_login.try &.user!
+    getter? current_bearer_user : User? do
+      current_bearer_login?.try &.user!
     end
 
-    def current_bearer_login! : BearerLogin
-      current_bearer_login.not_nil!
+    def current_bearer_login
+      current_bearer_login?.not_nil!
     end
 
-    getter current_bearer_login : BearerLogin? do
+    getter? current_bearer_login : BearerLogin? do
       BearerLoginHeaders.new(request.headers).verify
     end
   end

--- a/src/shield/actions/api/login_pipes.cr
+++ b/src/shield/actions/api/login_pipes.cr
@@ -23,10 +23,10 @@ module Shield::Api::LoginPipes
 
     def pin_login_to_ip_address
       if logged_out? ||
-        current_login!.ip_address == remote_ip.try &.address
+        current_login.ip_address == remote_ip?.try &.address
         continue
       else
-        LogUserOut.update!(current_login!, session: nil)
+        LogUserOut.update!(current_login, session: nil)
         response.status_code = 403
         do_pin_login_to_ip_address_failed
       end

--- a/src/shield/actions/api/logins/index.cr
+++ b/src/shield/actions/api/logins/index.cr
@@ -28,7 +28,7 @@ module Shield::Api::Logins::Index
     end
 
     def user
-      current_or_bearer_user!
+      current_or_bearer_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/api/password_reset_pipes.cr
+++ b/src/shield/actions/api/password_reset_pipes.cr
@@ -3,11 +3,11 @@ module Shield::Api::PasswordResetPipes
     include Shield::PasswordResetPipes
 
     def pin_password_reset_to_ip_address
-      password_reset = PasswordResetParams.new(params).password_reset
+      password_reset = PasswordResetParams.new(params).password_reset?
 
       if password_reset.nil? ||
         !password_reset.not_nil!.active? ||
-        password_reset.not_nil!.ip_address == remote_ip.try &.address
+        password_reset.not_nil!.ip_address == remote_ip?.try &.address
         continue
       else
         EndPasswordReset.update!(password_reset.not_nil!, session: nil)

--- a/src/shield/actions/api/password_resets/create.cr
+++ b/src/shield/actions/api/password_resets/create.cr
@@ -17,7 +17,7 @@ module Shield::Api::PasswordResets::Create
     def run_operation
       StartPasswordReset.create(
         params,
-        remote_ip: remote_ip
+        remote_ip: remote_ip?
       ) do |operation, password_reset|
         if password_reset
           do_run_operation_succeeded(operation, password_reset.not_nil!)

--- a/src/shield/actions/api/password_resets/update.cr
+++ b/src/shield/actions/api/password_resets/update.cr
@@ -28,7 +28,7 @@ module Shield::Api::PasswordResets::Update
         password_reset.user!,
         params,
         session: nil,
-        current_login: current_login
+        current_login: current_login?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)

--- a/src/shield/actions/api/skip_authentication_cache.cr
+++ b/src/shield/actions/api/skip_authentication_cache.cr
@@ -2,15 +2,15 @@ module Shield::Api::SkipAuthenticationCache
   macro included
     include Shield::SkipAuthenticationCache
 
-    def current_login : Login?
+    def current_login? : Login?
       LoginHeaders.new(request.headers).verify
     end
 
-    def current_bearer_user : User?
-      current_bearer_login.try &.user!
+    def current_bearer_user? : User?
+      current_bearer_login?.try &.user!
     end
 
-    def current_bearer_login : BearerLogin?
+    def current_bearer_login? : BearerLogin?
       BearerLoginHeaders.new(request.headers).verify
     end
   end

--- a/src/shield/actions/api/users/delete.cr
+++ b/src/shield/actions/api/users/delete.cr
@@ -9,7 +9,7 @@ module Shield::Api::Users::Delete
     def run_operation
       DeleteUser.delete(
         user,
-        current_user: current_user
+        current_user: current_user?
       ) do |operation, deleted_user|
         if operation.deleted?
           do_run_operation_succeeded(operation, deleted_user.not_nil!)

--- a/src/shield/actions/api/users/update.cr
+++ b/src/shield/actions/api/users/update.cr
@@ -10,7 +10,7 @@ module Shield::Api::Users::Update
       UpdateUser.update(
         user,
         params,
-        current_login: current_login
+        current_login: current_login?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)

--- a/src/shield/actions/authorization_pipes.cr
+++ b/src/shield/actions/authorization_pipes.cr
@@ -3,7 +3,7 @@ module Shield::AuthorizationPipes
     before :check_authorization
 
     def check_authorization
-      if logged_out? || authorize?(current_user!)
+      if logged_out? || authorize?(current_user)
         continue
       else
         response.status_code = 403

--- a/src/shield/actions/bearer_logins/create.cr
+++ b/src/shield/actions/bearer_logins/create.cr
@@ -22,7 +22,7 @@ module Shield::BearerLogins::Create
     end
 
     def user
-      current_user!
+      current_user
     end
 
     def do_run_operation_succeeded(operation, bearer_login)

--- a/src/shield/actions/bearer_logins/index.cr
+++ b/src/shield/actions/bearer_logins/index.cr
@@ -27,7 +27,7 @@ module Shield::BearerLogins::Index
     end
 
     def user
-      current_user!
+      current_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/bearer_logins/new.cr
+++ b/src/shield/actions/bearer_logins/new.cr
@@ -12,7 +12,7 @@ module Shield::BearerLogins::New
     # end
 
     def user
-      current_user!
+      current_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/current_login/create.cr
+++ b/src/shield/actions/current_login/create.cr
@@ -10,7 +10,7 @@ module Shield::CurrentLogin::Create
       LogUserIn.create(
         params,
         session: session,
-        remote_ip: remote_ip
+        remote_ip: remote_ip?
       ) do |operation, login|
         if login
           do_run_operation_succeeded(operation, login.not_nil!)

--- a/src/shield/actions/current_login/destroy.cr
+++ b/src/shield/actions/current_login/destroy.cr
@@ -17,7 +17,7 @@ module Shield::CurrentLogin::Destroy
     end
 
     def login
-      current_login!
+      current_login
     end
 
     def do_run_operation_succeeded(operation, login)

--- a/src/shield/actions/current_login/new.cr
+++ b/src/shield/actions/current_login/new.cr
@@ -3,7 +3,7 @@ module Shield::CurrentLogin::New
     skip :require_logged_in
 
     # get "/login" do
-    #   operation = LogUserIn.new(remote_ip: remote_ip, session: session)
+    #   operation = LogUserIn.new(remote_ip: remote_ip?, session: session)
     #   html NewPage, operation: operation
     # end
   end

--- a/src/shield/actions/current_user/edit.cr
+++ b/src/shield/actions/current_user/edit.cr
@@ -3,12 +3,12 @@ module Shield::CurrentUser::Edit
     skip :require_logged_out
 
     # get "/account/edit" do
-    #   operation = UpdateCurrentUser.new(user, current_login: current_login)
+    #   operation = UpdateCurrentUser.new(user, current_login: current_login?)
     #   html EditPage, operation: operation
     # end
 
     def user
-      current_user!
+      current_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/current_user/show.cr
+++ b/src/shield/actions/current_user/show.cr
@@ -7,7 +7,7 @@ module Shield::CurrentUser::Show
     # end
 
     def user
-      current_user!
+      current_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/current_user/update.cr
+++ b/src/shield/actions/current_user/update.cr
@@ -10,7 +10,7 @@ module Shield::CurrentUser::Update
       UpdateCurrentUser.update(
         user,
         params,
-        current_login: current_login
+        current_login: current_login?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)
@@ -21,7 +21,7 @@ module Shield::CurrentUser::Update
     end
 
     def user
-      current_user!
+      current_user
     end
 
     def do_run_operation_succeeded(operation, user)

--- a/src/shield/actions/email_confirmation_current_user/edit.cr
+++ b/src/shield/actions/email_confirmation_current_user/edit.cr
@@ -5,8 +5,8 @@ module Shield::EmailConfirmationCurrentUser::Edit
     # get "/account/edit" do
     #   operation = UpdateCurrentUser.new(
     #     user,
-    #     remote_ip: remote_ip,
-    #     current_login: current_login
+    #     remote_ip: remote_ip?,
+    #     current_login: current_login?
     #   )
     #
     #   html EditPage, operation: operation

--- a/src/shield/actions/email_confirmation_current_user/update.cr
+++ b/src/shield/actions/email_confirmation_current_user/update.cr
@@ -10,8 +10,8 @@ module Shield::EmailConfirmationCurrentUser::Update
       UpdateCurrentUser.update(
         user,
         params,
-        current_login: current_login,
-        remote_ip: remote_ip
+        current_login: current_login?,
+        remote_ip: remote_ip?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)

--- a/src/shield/actions/email_confirmation_pipes.cr
+++ b/src/shield/actions/email_confirmation_pipes.cr
@@ -2,11 +2,11 @@ module Shield::EmailConfirmationPipes
   macro included
     def pin_email_confirmation_to_ip_address
       email_confirmation_session = EmailConfirmationSession.new(session)
-      email_confirmation = email_confirmation_session.email_confirmation
+      email_confirmation = email_confirmation_session.email_confirmation?
 
       if email_confirmation.nil? ||
         !email_confirmation.not_nil!.active? ||
-        email_confirmation.not_nil!.ip_address == remote_ip.try &.address
+        email_confirmation.not_nil!.ip_address == remote_ip?.try &.address
         continue
       else
         EndEmailConfirmation.update!(

--- a/src/shield/actions/email_confirmations/create.cr
+++ b/src/shield/actions/email_confirmations/create.cr
@@ -13,7 +13,7 @@ module Shield::EmailConfirmations::Create
     def run_operation
       StartEmailConfirmation.create(
         params,
-        remote_ip: remote_ip
+        remote_ip: remote_ip?
       ) do |operation, email_confirmation|
         if email_confirmation
           do_run_operation_succeeded(operation, email_confirmation.not_nil!)

--- a/src/shield/actions/email_confirmations/edit.cr
+++ b/src/shield/actions/email_confirmations/edit.cr
@@ -35,7 +35,7 @@ module Shield::EmailConfirmations::Edit
     end
 
     def user
-      current_user!
+      current_user
     end
 
     def do_verify_operation_failed(utility)

--- a/src/shield/actions/email_confirmations/new.cr
+++ b/src/shield/actions/email_confirmations/new.cr
@@ -3,7 +3,7 @@ module Shield::EmailConfirmations::New
     skip :require_logged_in
 
     # get "/email-confirmations/new" do
-    #   operation = StartEmailConfirmation.new(remote_ip: remote_ip)
+    #   operation = StartEmailConfirmation.new(remote_ip: remote_ip?)
     #   html NewPage, operation: operation
     # end
   end

--- a/src/shield/actions/email_confirmations/show.cr
+++ b/src/shield/actions/email_confirmations/show.cr
@@ -36,7 +36,7 @@ module Shield::EmailConfirmations::Show
     end
 
     def authorize?(user : User) : Bool
-      user.id == current_user.try &.id
+      user.id == current_user?.try &.id
     end
   end
 end

--- a/src/shield/actions/login_helpers.cr
+++ b/src/shield/actions/login_helpers.cr
@@ -5,22 +5,22 @@ module Shield::LoginHelpers
     end
 
     def logged_out? : Bool
-      current_user.nil?
+      current_user?.nil?
     end
 
-    def current_user! : User
-      current_user.not_nil!
+    def current_user
+      current_user?.not_nil!
     end
 
-    getter current_user : User? do
-      current_login.try &.user!
+    getter? current_user : User? do
+      current_login?.try &.user!
     end
 
-    def current_login! : Login
-      current_login.not_nil!
+    def current_login
+      current_login?.not_nil!
     end
 
-    getter current_login : Login? do
+    getter? current_login : Login? do
       LoginSession.new(session).verify
     end
   end

--- a/src/shield/actions/login_pipes.cr
+++ b/src/shield/actions/login_pipes.cr
@@ -26,10 +26,10 @@ module Shield::LoginPipes
 
     def pin_login_to_ip_address
       if logged_out? ||
-        current_login!.ip_address == remote_ip.try &.address
+        current_login.ip_address == remote_ip?.try &.address
         continue
       else
-        LogUserOut.update!(current_login!, session: session)
+        LogUserOut.update!(current_login, session: session)
         response.status_code = 403
         do_pin_login_to_ip_address_failed
       end
@@ -42,7 +42,7 @@ module Shield::LoginPipes
         timeout_session.delete
         continue
       elsif timeout_session.expired?
-        LogUserOut.update!(current_login!, session: session)
+        LogUserOut.update!(current_login, session: session)
         response.status_code = 403
         do_enforce_login_idle_timeout_failed
       else

--- a/src/shield/actions/logins/index.cr
+++ b/src/shield/actions/logins/index.cr
@@ -21,7 +21,7 @@ module Shield::Logins::Index
     end
 
     def user
-      current_user!
+      current_user
     end
 
     def authorize?(user : User) : Bool

--- a/src/shield/actions/password_reset_pipes.cr
+++ b/src/shield/actions/password_reset_pipes.cr
@@ -1,11 +1,11 @@
 module Shield::PasswordResetPipes
   macro included
     def pin_password_reset_to_ip_address
-      password_reset = PasswordResetSession.new(session).password_reset
+      password_reset = PasswordResetSession.new(session).password_reset?
 
       if password_reset.nil? ||
         !password_reset.not_nil!.active? ||
-        password_reset.not_nil!.ip_address == remote_ip.try &.address
+        password_reset.not_nil!.ip_address == remote_ip?.try &.address
         continue
       else
         EndPasswordReset.update!(password_reset.not_nil!, session: session)

--- a/src/shield/actions/password_resets/create.cr
+++ b/src/shield/actions/password_resets/create.cr
@@ -17,7 +17,7 @@ module Shield::PasswordResets::Create
     def run_operation
       StartPasswordReset.create(
         params,
-        remote_ip: remote_ip
+        remote_ip: remote_ip?
       ) do |operation, password_reset|
         if password_reset
           do_run_operation_succeeded(operation, password_reset.not_nil!)

--- a/src/shield/actions/password_resets/edit.cr
+++ b/src/shield/actions/password_resets/edit.cr
@@ -23,7 +23,7 @@ module Shield::PasswordResets::Edit
       operation = ResetPassword.new(
         password_reset.user!,
         session: session,
-        current_login: current_login
+        current_login: current_login?
       )
 
       html EditPage, operation: operation

--- a/src/shield/actions/password_resets/new.cr
+++ b/src/shield/actions/password_resets/new.cr
@@ -3,7 +3,7 @@ module Shield::PasswordResets::New
     skip :require_logged_in
 
     # get "/password-resets/new" do
-    #   operation = StartPasswordReset.new(remote_ip: remote_ip)
+    #   operation = StartPasswordReset.new(remote_ip: remote_ip?)
     #   html NewPage, operation: operation
     # end
   end

--- a/src/shield/actions/password_resets/update.cr
+++ b/src/shield/actions/password_resets/update.cr
@@ -29,7 +29,7 @@ module Shield::PasswordResets::Update
         password_reset.user!,
         params,
         session: session,
-        current_login: current_login
+        current_login: current_login?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)

--- a/src/shield/actions/skip_authentication_cache.cr
+++ b/src/shield/actions/skip_authentication_cache.cr
@@ -1,10 +1,10 @@
 module Shield::SkipAuthenticationCache
   macro included
-    def current_user : User?
-      current_login.try &.user!
+    def current_user? : User?
+      current_login?.try &.user!
     end
 
-    def current_login : Login?
+    def current_login? : Login?
       LoginSession.new(session).verify
     end
   end

--- a/src/shield/actions/users/delete.cr
+++ b/src/shield/actions/users/delete.cr
@@ -9,7 +9,7 @@ module Shield::Users::Delete
     def run_operation
       DeleteUser.delete(
         user,
-        current_user: current_user
+        current_user: current_user?
       ) do |operation, deleted_user|
         if operation.deleted?
           do_run_operation_succeeded(operation, deleted_user.not_nil!)

--- a/src/shield/actions/users/edit.cr
+++ b/src/shield/actions/users/edit.cr
@@ -3,7 +3,7 @@ module Shield::Users::Edit
     skip :require_logged_out
 
     # get "/users/:user_id/edit" do
-    #   operation = UpdateUser.new(user, current_login: current_login)
+    #   operation = UpdateUser.new(user, current_login: current_login?)
     #   html EditPage, operation: operation
     # end
 

--- a/src/shield/actions/users/update.cr
+++ b/src/shield/actions/users/update.cr
@@ -10,7 +10,7 @@ module Shield::Users::Update
       UpdateUser.update(
         user,
         params,
-        current_login: current_login
+        current_login: current_login?
       ) do |operation, updated_user|
         if operation.saved?
           do_run_operation_succeeded(operation, updated_user)

--- a/src/shield/http_client.cr
+++ b/src/shield/http_client.cr
@@ -69,14 +69,14 @@ module Shield::HttpClient
     end
 
     def set_cookie_from_session(session : Lucky::Session)
-      headers("Cookie": self.class.cookie_from_session(session).to_s)
-    end
-
-    def self.cookie_from_session!(session : Lucky::Session)
-      cookie_from_session(session).not_nil!
+      headers("Cookie": self.class.cookie_from_session?(session).to_s)
     end
 
     def self.cookie_from_session(session : Lucky::Session)
+      cookie_from_session?(session).not_nil!
+    end
+
+    def self.cookie_from_session?(session : Lucky::Session)
       cookies = Lucky::CookieJar.empty_jar
       cookies.set(Lucky::Session.settings.key, session.to_json)
       cookies.updated.add_response_headers(HTTP::Headers.new)["Set-Cookie"]?

--- a/src/shield/operations/create_bearer_login.cr
+++ b/src/shield/operations/create_bearer_login.cr
@@ -13,7 +13,8 @@ module Shield::CreateBearerLogin
     include Shield::StartAuthentication
 
     private def set_inactive_at
-      inactive_at.value = active_at.value! + Shield.settings.bearer_login_expiry
+      inactive_at.value = active_at.value.not_nil! + \
+        Shield.settings.bearer_login_expiry
     end
 
     # Prevents a user from using a bearer login `name`

--- a/src/shield/operations/delete_user.cr
+++ b/src/shield/operations/delete_user.cr
@@ -8,7 +8,7 @@ module Shield::DeleteUser
 
     private def validate_not_current_user
       current_user.try do |current_user|
-        id.add_error("is current user") if current_user.id == record!.id
+        id.add_error("is current user") if current_user.id == record.id
       end
     end
   end

--- a/src/shield/operations/log_user_in.cr
+++ b/src/shield/operations/log_user_in.cr
@@ -15,13 +15,16 @@ module Shield::LogUserIn
     include Shield::SetSession
 
     private def set_inactive_at
-      inactive_at.value = active_at.value! + Shield.settings.login_expiry
+      inactive_at.value = active_at.value.not_nil! + \
+        Shield.settings.login_expiry
     end
 
     private def verify_login
       return unless email.value && password.value
 
-      if user = PasswordAuthentication.new(email.value!).verify(password.value!)
+      if user = PasswordAuthentication.new(email.value.not_nil!)
+        .verify(password.value.not_nil!)
+
         user_id.value = user.id
       else
         email.add_error "may be incorrect"

--- a/src/shield/operations/start_email_confirmation.cr
+++ b/src/shield/operations/start_email_confirmation.cr
@@ -13,7 +13,7 @@ module Shield::StartEmailConfirmation
     end
 
     private def set_inactive_at
-      inactive_at.value = active_at.value! +
+      inactive_at.value = active_at.value.not_nil! +
         Shield.settings.email_confirmation_expiry
     end
 

--- a/src/shield/operations/start_password_reset.cr
+++ b/src/shield/operations/start_password_reset.cr
@@ -22,7 +22,7 @@ module Shield::StartPasswordReset
     include Shield::StartAuthentication
 
     private def set_inactive_at
-      inactive_at.value = active_at.value! +
+      inactive_at.value = active_at.value.not_nil! +
         Shield.settings.password_reset_expiry
     end
 

--- a/src/shield/utilities/bearer_login_headers.cr
+++ b/src/shield/utilities/bearer_login_headers.cr
@@ -5,16 +5,16 @@ module Shield::BearerLoginHeaders
     def initialize(@headers : HTTP::Headers)
     end
 
-    def bearer_login_id : Int64?
+    def bearer_login_id? : Int64?
       token_from_headers.try &.id
     end
 
-    def bearer_login_token : String?
+    def bearer_login_token? : String?
       token_from_headers.try &.token
     end
 
     private getter token_from_headers : BearerToken? do
-      BearerToken.from_headers(@headers)
+      BearerToken.from_headers?(@headers)
     end
   end
 end

--- a/src/shield/utilities/email_confirmation_params.cr
+++ b/src/shield/utilities/email_confirmation_params.cr
@@ -5,16 +5,16 @@ module Shield::EmailConfirmationParams
     def initialize(@params : Avram::Paramable)
     end
 
-    def email_confirmation_id : Int64?
+    def email_confirmation_id? : Int64?
       token_from_params.try &.id
     end
 
-    def email_confirmation_token : String?
+    def email_confirmation_token? : String?
       token_from_params.try &.token
     end
 
     private getter token_from_params : BearerToken? do
-      BearerToken.from_params(@params)
+      BearerToken.from_params?(@params)
     end
   end
 end

--- a/src/shield/utilities/email_confirmation_session.cr
+++ b/src/shield/utilities/email_confirmation_session.cr
@@ -3,16 +3,16 @@ module Shield::EmailConfirmationSession
     include Shield::Session
     include Shield::EmailConfirmationVerifier
 
-    def email_confirmation_id : Int64?
+    def email_confirmation_id? : Int64?
       @session.get?(:email_confirmation_id).try &.to_i64?
     end
 
-    def email_confirmation_token : String?
+    def email_confirmation_token? : String?
       @session.get?(:email_confirmation_token)
     end
 
     def delete(email_confirmation : EmailConfirmation) : self
-      delete if email_confirmation.id == email_confirmation_id
+      delete if email_confirmation.id == email_confirmation_id?
       self
     end
 
@@ -31,7 +31,7 @@ module Shield::EmailConfirmationSession
 
     def set(token : String) : self
       bearer_token = BearerToken.new(token)
-      set(bearer_token.token, bearer_token.id)
+      set(bearer_token.token, bearer_token.id?)
     end
 
     def set(token : String, id) : self

--- a/src/shield/utilities/login_headers.cr
+++ b/src/shield/utilities/login_headers.cr
@@ -5,16 +5,16 @@ module Shield::LoginHeaders
     def initialize(@headers : HTTP::Headers)
     end
 
-    def login_id : Int64?
+    def login_id? : Int64?
       token_from_headers.try &.id
     end
 
-    def login_token : String?
+    def login_token? : String?
       token_from_headers.try &.token
     end
 
     private getter token_from_headers : BearerToken? do
-      BearerToken.from_headers(@headers)
+      BearerToken.from_headers?(@headers)
     end
   end
 end

--- a/src/shield/utilities/login_idle_timeout_session.cr
+++ b/src/shield/utilities/login_idle_timeout_session.cr
@@ -3,23 +3,23 @@ module Shield::LoginIdleTimeoutSession
     include Shield::Session
 
     def expired? : Bool?
-      login_last_active.try do |time|
+      login_last_active?.try do |time|
         Time.utc - time >= Shield.settings.login_idle_timeout
       end
     end
 
-    def login_last_active! : Time
-      login_last_active.not_nil!
+    def login_last_active : Time
+      login_last_active?.not_nil!
     end
 
-    def login_last_active : Time?
+    def login_last_active? : Time?
       @session.get?(:login_last_active).try &.to_i64?.try do |time|
         Time.unix(time)
       end
     end
 
     def delete(login : Login) : self
-      delete if login.id == LoginSession.new(@session).login_id
+      delete if login.id == LoginSession.new(@session).login_id?
       self
     end
 

--- a/src/shield/utilities/login_session.cr
+++ b/src/shield/utilities/login_session.cr
@@ -3,16 +3,16 @@ module Shield::LoginSession
     include Shield::Session
     include Shield::LoginVerifier
 
-    def login_id : Int64?
+    def login_id? : Int64?
       @session.get?(:login_id).try &.to_i64?
     end
 
-    def login_token : String?
+    def login_token? : String?
       @session.get?(:login_token)
     end
 
     def delete(login : Login) : self
-      delete if login.id == login_id
+      delete if login.id == login_id?
       self
     end
 
@@ -28,7 +28,7 @@ module Shield::LoginSession
 
     def set(token : String) : self
       bearer_token = BearerToken.new(token)
-      set(bearer_token.token, bearer_token.id)
+      set(bearer_token.token, bearer_token.id?)
     end
 
     def set(token : String, id) : self

--- a/src/shield/utilities/mixins/bearer_login_verifier.cr
+++ b/src/shield/utilities/mixins/bearer_login_verifier.cr
@@ -3,34 +3,34 @@ module Shield::BearerLoginVerifier
     include Shield::Verifier
 
     def verify : BearerLogin?
-      bearer_login if verify?
+      bearer_login? if verify?
     end
 
     def verify? : Bool?
-      return unless bearer_login_id && bearer_login_token
-      sha256 = Sha256Hash.new(bearer_login_token!)
+      return unless bearer_login_id? && bearer_login_token?
+      sha256 = Sha256Hash.new(bearer_login_token)
 
-      if bearer_login.try(&.active?)
-        sha256.verify?(bearer_login!.token_digest)
+      if bearer_login?.try(&.active?)
+        sha256.verify?(bearer_login.token_digest)
       else
         sha256.fake_verify
       end
     end
 
-    def bearer_login! : BearerLogin
-      bearer_login.not_nil!
+    def bearer_login
+      bearer_login?.not_nil!
     end
 
-    getter bearer_login : BearerLogin? do
-      bearer_login_id.try { |id| BearerLoginQuery.new.id(id).first? }
+    getter? bearer_login : BearerLogin? do
+      bearer_login_id?.try { |id| BearerLoginQuery.new.id(id).first? }
     end
 
-    def bearer_login_id! : Int64
-      bearer_login_id.not_nil!
+    def bearer_login_id : Int64
+      bearer_login_id?.not_nil!
     end
 
-    def bearer_login_token! : String
-      bearer_login_token.not_nil!
+    def bearer_login_token : String
+      bearer_login_token?.not_nil!
     end
   end
 end

--- a/src/shield/utilities/mixins/email_confirmation_verifier.cr
+++ b/src/shield/utilities/mixins/email_confirmation_verifier.cr
@@ -3,36 +3,36 @@ module Shield::EmailConfirmationVerifier
     include Shield::Verifier
 
     def verify : EmailConfirmation?
-      email_confirmation if verify?
+      email_confirmation? if verify?
     end
 
     def verify? : Bool?
-      return unless email_confirmation_id && email_confirmation_token
-      sha256 = Sha256Hash.new(email_confirmation_token!)
+      return unless email_confirmation_id? && email_confirmation_token?
+      sha256 = Sha256Hash.new(email_confirmation_token)
 
-      if email_confirmation.try(&.active?)
-        sha256.verify?(email_confirmation!.token_digest)
+      if email_confirmation?.try(&.active?)
+        sha256.verify?(email_confirmation.token_digest)
       else
         sha256.fake_verify
       end
     end
 
-    def email_confirmation! : EmailConfirmation
-      email_confirmation.not_nil!
+    def email_confirmation
+      email_confirmation?.not_nil!
     end
 
-    getter email_confirmation : EmailConfirmation? do
-      email_confirmation_id.try do |id|
+    getter? email_confirmation : EmailConfirmation? do
+      email_confirmation_id?.try do |id|
         EmailConfirmationQuery.new.id(id).first?
       end
     end
 
-    def email_confirmation_id! : Int64
-      email_confirmation_id.not_nil!
+    def email_confirmation_id : Int64
+      email_confirmation_id?.not_nil!
     end
 
-    def email_confirmation_token! : String
-      email_confirmation_token.not_nil!
+    def email_confirmation_token : String
+      email_confirmation_token?.not_nil!
     end
   end
 end

--- a/src/shield/utilities/mixins/login_verifier.cr
+++ b/src/shield/utilities/mixins/login_verifier.cr
@@ -3,34 +3,34 @@ module Shield::LoginVerifier
     include Shield::Verifier
 
     def verify : Login?
-      login if verify?
+      login? if verify?
     end
 
     def verify? : Bool?
-      return unless login_id && login_token
-      sha256 = Sha256Hash.new(login_token!)
+      return unless login_id? && login_token?
+      sha256 = Sha256Hash.new(login_token)
 
-      if login.try(&.active?)
-        sha256.verify?(login!.token_digest)
+      if login?.try(&.active?)
+        sha256.verify?(login.token_digest)
       else
         sha256.fake_verify
       end
     end
 
-    def login! : Login
-      login.not_nil!
+    def login
+      login?.not_nil!
     end
 
-    getter login : Login? do
-      login_id.try { |id| LoginQuery.new.id(id).first? }
+    getter? login : Login? do
+      login_id?.try { |id| LoginQuery.new.id(id).first? }
     end
 
-    def login_id! : Int64
-      login_id.not_nil!
+    def login_id : Int64
+      login_id?.not_nil!
     end
 
-    def login_token! : String
-      login_token.not_nil!
+    def login_token : String
+      login_token?.not_nil!
     end
   end
 end

--- a/src/shield/utilities/mixins/password_reset_verifier.cr
+++ b/src/shield/utilities/mixins/password_reset_verifier.cr
@@ -3,34 +3,34 @@ module Shield::PasswordResetVerifier
     include Shield::Verifier
 
     def verify : PasswordReset?
-      password_reset if verify?
+      password_reset? if verify?
     end
 
     def verify? : Bool?
-      return unless password_reset_id && password_reset_token
-      sha256 = Sha256Hash.new(password_reset_token!)
+      return unless password_reset_id? && password_reset_token?
+      sha256 = Sha256Hash.new(password_reset_token)
 
-      if password_reset.try(&.active?)
-        sha256.verify?(password_reset!.token_digest)
+      if password_reset?.try(&.active?)
+        sha256.verify?(password_reset.token_digest)
       else
         sha256.fake_verify
       end
     end
 
-    def password_reset! : PasswordReset
-      password_reset.not_nil!
+    def password_reset
+      password_reset?.not_nil!
     end
 
-    getter password_reset : PasswordReset? do
-      password_reset_id.try { |id| PasswordResetQuery.new.id(id).first? }
+    getter? password_reset : PasswordReset? do
+      password_reset_id?.try { |id| PasswordResetQuery.new.id(id).first? }
     end
 
-    def password_reset_id! : Int64
-      password_reset_id.not_nil!
+    def password_reset_id : Int64
+      password_reset_id?.not_nil!
     end
 
-    def password_reset_token! : String
-      password_reset_token.not_nil!
+    def password_reset_token : String
+      password_reset_token?.not_nil!
     end
   end
 end

--- a/src/shield/utilities/page_url_session.cr
+++ b/src/shield/utilities/page_url_session.cr
@@ -2,11 +2,11 @@ module Shield::PageUrlSession
   macro included
     include Shield::Session
 
-    def previous_page_url! : String
-      previous_page_url.not_nil!
+    def previous_page_url : String
+      previous_page_url?.not_nil!
     end
 
-    def previous_page_url : String?
+    def previous_page_url? : String?
       @session.get?(:previous_page_url).try do |url|
         delete
         url

--- a/src/shield/utilities/password_reset_params.cr
+++ b/src/shield/utilities/password_reset_params.cr
@@ -5,16 +5,16 @@ module Shield::PasswordResetParams
     def initialize(@params : Avram::Paramable)
     end
 
-    def password_reset_id : Int64?
+    def password_reset_id? : Int64?
       token_from_params.try &.id
     end
 
-    def password_reset_token : String?
+    def password_reset_token? : String?
       token_from_params.try &.token
     end
 
     private getter token_from_params : BearerToken? do
-      BearerToken.from_params(@params)
+      BearerToken.from_params?(@params)
     end
   end
 end

--- a/src/shield/utilities/password_reset_session.cr
+++ b/src/shield/utilities/password_reset_session.cr
@@ -3,16 +3,16 @@ module Shield::PasswordResetSession
     include Shield::Session
     include Shield::PasswordResetVerifier
 
-    def password_reset_id : Int64?
+    def password_reset_id? : Int64?
       @session.get?(:password_reset_id).try &.to_i64?
     end
 
-    def password_reset_token : String?
+    def password_reset_token? : String?
       @session.get?(:password_reset_token)
     end
 
     def delete(password_reset : PasswordReset) : self
-      delete if password_reset.id == password_reset_id
+      delete if password_reset.id == password_reset_id?
       self
     end
 
@@ -31,7 +31,7 @@ module Shield::PasswordResetSession
 
     def set(token : String) : self
       bearer_token = BearerToken.new(token)
-      set(bearer_token.token, bearer_token.id)
+      set(bearer_token.token, bearer_token.id?)
     end
 
     def set(token : String, id) : self

--- a/src/shield/utilities/return_url_session.cr
+++ b/src/shield/utilities/return_url_session.cr
@@ -2,11 +2,11 @@ module Shield::ReturnUrlSession
   macro included
     include Shield::Session
 
-    def return_url! : String
-      return_url.not_nil!
+    def return_url : String
+      return_url?.not_nil!
     end
 
-    def return_url : String?
+    def return_url? : String?
       @session.get?(:return_url).try do |url|
         delete
         url


### PR DESCRIPTION
Renaming *bang* counterparts of nilable methods to their non-bang equivalents. Also appending `?` to names of methods with nilable return values.

So `#current_user!` now becomes `#current_user`, with `#current_user?` as the nilable version.

My justifications are:

- This is in line with the standard library's style, when one uses the `.getter!` macro.
- *Avram* uses bang methods to mean eager load the record. *Shield* using that to mean a method is not nil is kinda confusing.
- Nilable methods can be used safely in conditions, like boolean methods, hence deserve similar *treatment*.
- This is the common convention.

The change only applies to nilable methods that are nouns (eg: `remote_ip?`), rather than verbs (eg: `#verify`).